### PR TITLE
feat(AutoCollectionsManager.cs): sort collection items by premiere date when adding wanted items

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -298,7 +298,7 @@ namespace Jellyfin.Plugin.AutoCollections
 
             // Get current items and filter for unwanted ones
             var childrenToRemove = collection.GetLinkedChildren()
-                .Where(item => !wantedItemIds.Contains(item.Id))
+                // .Where(item => !wantedItemIds.Contains(item.Id)) // Remove all items in the collection because we want to sort by premiere date when adding wanted items to the collection
                 .Select(item => item.Id)
                 .ToArray();
 
@@ -314,11 +314,12 @@ namespace Jellyfin.Plugin.AutoCollections
             // Get the set of IDs for items currently in the collection
             var existingItemIds = collection.GetLinkedChildren()
                 .Select(item => item.Id)
-                .ToHashSet();
+                .ToHashSet();            
 
             // Create LinkedChild objects for items that aren't already in the collection
             var childrenToAdd = wantedMediaItems
                 .Where(item => !existingItemIds.Contains(item.Id))
+                .OrderByDescending(item => item.PremiereDate ?? DateTime.MinValue)
                 .Select(item => item.Id)
                 .ToArray();
 

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -319,7 +319,7 @@ namespace Jellyfin.Plugin.AutoCollections
             // Create LinkedChild objects for items that aren't already in the collection
             var childrenToAdd = wantedMediaItems
                 .Where(item => !existingItemIds.Contains(item.Id))
-                .OrderByDescending(item => item.Year)
+                .OrderByDescending(item => item.ProductionYear)
                 .OrderByDescending(item => item.PremiereDate ?? DateTime.MinValue)
                 .Select(item => item.Id)
                 .ToArray();

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -319,6 +319,7 @@ namespace Jellyfin.Plugin.AutoCollections
             // Create LinkedChild objects for items that aren't already in the collection
             var childrenToAdd = wantedMediaItems
                 .Where(item => !existingItemIds.Contains(item.Id))
+                .OrderByDescending(item => item.Year)
                 .OrderByDescending(item => item.PremiereDate ?? DateTime.MinValue)
                 .Select(item => item.Id)
                 .ToArray();


### PR DESCRIPTION
close #17 

Hi @KeksBombe ,

I quickly made a patch based on the requirements of #17 to allow Collection to be sorted by year and date.

Although customization is not possible and currently only the Descending sorting mode is available, at least there is a sorting option to make the content of the Collection more organized.

I hope the author can merge it as soon as possible. If there are more in-depth customized contents in the future, they can be released gradually later. Thank you.

---

This pull request updates the logic for managing items in a collection to ensure that items are always sorted by premiere date when added. Specifically, it removes all current items from the collection before re-adding the desired items in the correct order.

Collection management and sorting improvements:

* Modified the removal logic in `RemoveUnwantedMediaItems` to remove all items from the collection, regardless of whether they are wanted, to allow for reordering by premiere date.
* Updated the addition logic in `AddWantedMediaItems` to order the items being added by descending `ProductionYear` and then by descending `PremiereDate`, ensuring the collection is sorted as desired.