### PR TITLE
Implement filename filter

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -1040,6 +1040,9 @@ namespace Jellyfin.Plugin.AutoCollections
                         return movie.CustomRating.Contains(value, comparison);
                     }
                     return false;
+
+                case Configuration.CriteriaType.Filename:
+                    return !string.IsNullOrEmpty(movie.Path) && movie.Path.Contains(value, comparison);
                     
                 default:
                     return false;
@@ -1176,6 +1179,23 @@ namespace Jellyfin.Plugin.AutoCollections
                             }
                         }
                         return series.CustomRating.Contains(value, comparison);
+                    }
+                    return false;
+
+                case Configuration.CriteriaType.Filename:
+                    var episodesForFilename = _libraryManager.GetItemList(new InternalItemsQuery
+                    {
+                        AncestorIds = new[] { series.Id },
+                        IncludeItemTypes = new[] { BaseItemKind.Episode },
+                        Recursive = true
+                    });
+
+                    foreach (var episode in episodesForFilename)
+                    {
+                        if (!string.IsNullOrEmpty(episode.Path) && episode.Path.Contains(value, comparison))
+                        {
+                            return true;
+                        }
                     }
                     return false;
                     

--- a/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
@@ -22,7 +22,8 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         AudioLanguage = 12, // Match by audio language
         Subtitle = 13, // Match by subtitle language
     Year = 14,      // Match by production/release year
-    CustomRating = 15 // Match by custom rating (user-provided override)
+    CustomRating = 15, // Match by custom rating (user-provided override)
+    Filename = 16 // Match by filename
     }
 
     // Token types for expression parsing
@@ -393,6 +394,12 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
                     continue;
                 }
 
+                if (TryMatchCriteria(expression, ref position, "FILENAME", out var filenameToken))
+                {
+                    tokens.Add(filenameToken);
+                    continue;
+                }
+
                 // Check for parentheses
                 if (expression[position] == '(')
                 {
@@ -542,6 +549,9 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
                         case "CUSTOMRATING":
                         case "CUSTOM":
                             token.CriteriaType = Configuration.CriteriaType.CustomRating;
+                            break;
+                        case "FILENAME":
+                            token.CriteriaType = Configuration.CriteriaType.Filename;
                             break;
                     }
                     

--- a/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
@@ -124,6 +124,7 @@
                 <div class="help-text">
                   Create collections using complex boolean expressions. Examples:<br>
                   <code>TITLE "Avengers"</code> - Items with "Avengers" in the title<br>
+                  <code>FILENAME "REMUX"</code> - Items with "REMUX" in the filename<br>
                   <code>STUDIO "Marvel" AND GENRE "Action"</code> - Marvel action items<br>
                   <code>STUDIO "Marvel" AND (TITLE "Spiderman" OR ACTOR "Robert Downey JR.")</code> - Marvel items with Spiderman in the title or starring Robert Downey Jr.<br>
                   <code>GENRE "Action" AND MOVIE</code> - Action movies only (no TV shows)<br>
@@ -761,7 +762,7 @@
             const criteriaTypes = [
             "TITLE", "GENRE", "STUDIO", "ACTOR", "DIRECTOR", "MOVIE", "SHOW",
             "TAG", "PARENTALRATING", "RATING", "COMMUNITYRATING", "CRITICSRATING",
-            "PRODUCTIONLOCATION", "LOCATION", "COUNTRY", "LANG", "SUB", "YEAR", "CUSTOMRATING", "CUSTOM"
+            "PRODUCTIONLOCATION", "LOCATION", "COUNTRY", "LANG", "SUB", "YEAR", "CUSTOMRATING", "CUSTOM", "FILENAME"
           ];
           let hasCriteria = false;
           
@@ -773,7 +774,7 @@
           }            if (!hasCriteria) {
             return { 
               valid: false, 
-              error: "Expression must contain at least one criteria (TITLE, GENRE, STUDIO, ACTOR, DIRECTOR, MOVIE, SHOW, TAG, PARENTALRATING, COMMUNITYRATING, CRITICSRATING, PRODUCTIONLOCATION, LANG, SUB, YEAR)" 
+              error: "Expression must contain at least one criteria (TITLE, GENRE, STUDIO, ACTOR, DIRECTOR, MOVIE, SHOW, TAG, PARENTALRATING, COMMUNITYRATING, CRITICSRATING, PRODUCTIONLOCATION, LANG, SUB, YEAR, FILENAME)" 
             // Note: validation error message not updated to include CUSTOMRATING for legacy backward compatibility UI; actual parser supports it
             };
           }


### PR DESCRIPTION
Using the advanced collection method, it is now possible to filter on the filename (not just the title). This allows filtering on things like quality (provided these details are part of the filename, of course).

Example for creating a "High-Quality" collection: `FILENAME "REMUX" OR (FILENAME "2160p" AND (FILENAME "DV" OR FILENAME "HDR"))`

Please look over the changes, I made them using Gemini-CLI. But I tested it on my server, and it works just how I want it.

Closes #11 