### PR TITLE
Add library, quality, crew and text filters; orphan cleanup (0.0.6.0)

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -59,6 +59,9 @@ namespace Jellyfin.Plugin.AutoCollections
         // Cache for item's people to avoid repeated DB calls
         // Key: item ID, Value: list of (personName, personType) tuples
         private Dictionary<Guid, List<(string Name, string Type)>>? _itemPeopleCache;
+        // Cache for the libraries an item belongs to
+        // Key: item ID, Value: names of the libraries containing it
+        private Dictionary<Guid, List<string>>? _itemLibrariesCache;
 
         // Constructor with IUserDataManager and IUserManager for full functionality
         public AutoCollectionsManager(IProviderManager providerManager, ICollectionManager collectionManager, ILibraryManager libraryManager, IUserDataManager userDataManager, IUserManager userManager, ILogger<AutoCollectionsManager> logger, IApplicationPaths applicationPaths)
@@ -285,6 +288,8 @@ namespace Jellyfin.Plugin.AutoCollections
                     movie.Tags != null && movie.Tags.Any(tag => 
                         !string.IsNullOrEmpty(tag) && tag.Equals(matchString, comparison))),
                 
+                Configuration.MatchType.Writer => GetMoviesWithPerson(matchString, "Writer", caseSensitive),
+                
                 _ => allMovies.Where(movie => 
                     !string.IsNullOrEmpty(movie.Name) && movie.Name.Contains(matchString, comparison))
             };
@@ -324,6 +329,8 @@ namespace Jellyfin.Plugin.AutoCollections
                         Configuration.MatchType.Tag => allSeries.Where(series => 
                             series.Tags != null && series.Tags.Any(tag => 
                                 !string.IsNullOrEmpty(tag) && tag.Equals(matchString, comparison))),
+                        
+                        Configuration.MatchType.Writer => GetSeriesWithPerson(matchString, "Writer", caseSensitive),
                         
                         _ => allSeries.Where(series => 
                             series.Name != null && series.Name.Contains(matchString, comparison)) // Default to title match
@@ -866,8 +873,74 @@ namespace Jellyfin.Plugin.AutoCollections
                 ClearPersonCache();
             }
 
+            if (Plugin.Instance!.Configuration.DeleteOrphanedCollections)
+            {
+                RemoveOrphanedCollections(
+                    titleMatchPairs.Select(p => p.CollectionName)
+                        .Concat(expressionCollections.Select(e => e.CollectionName)));
+            }
+
             progress.Report(100);
             _logger.LogInformation($"Completed execution of all {totalCollections} Auto collections");
+        }
+
+        /// <summary>
+        /// Deletes collections this plugin created that are no longer in the configuration.
+        /// </summary>
+        /// <remarks>
+        /// Only collections carrying the plugin's ownership tag are considered, so collections
+        /// made by hand or by another plugin are never touched. Skipped when the configuration
+        /// holds no collections at all, so a configuration that failed to load cannot wipe
+        /// every collection the plugin has ever made.
+        /// </remarks>
+        private void RemoveOrphanedCollections(IEnumerable<string> configuredNames)
+        {
+            var wanted = new HashSet<string>(
+                configuredNames.Where(name => !string.IsNullOrWhiteSpace(name)),
+                StringComparer.OrdinalIgnoreCase);
+
+            if (wanted.Count == 0)
+            {
+                _logger.LogInformation("No collections are configured, skipping orphan cleanup");
+                return;
+            }
+
+            var orphans = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = new[] { BaseItemKind.BoxSet },
+                CollapseBoxSetItems = false,
+                Recursive = true
+            }).OfType<BoxSet>()
+                .Where(boxSet =>
+                    boxSet.Tags != null &&
+                    boxSet.Tags.Contains(AutoCollectionTag, StringComparer.OrdinalIgnoreCase) &&
+                    !wanted.Contains(boxSet.Name))
+                .ToList();
+
+            if (orphans.Count == 0)
+            {
+                _logger.LogDebug("No orphaned collections to remove");
+                return;
+            }
+
+            foreach (var orphan in orphans)
+            {
+                try
+                {
+                    _logger.LogInformation(
+                        "Deleting orphaned collection '{CollectionName}' - no longer in the configuration",
+                        orphan.Name);
+
+                    _libraryManager.DeleteItem(
+                        orphan,
+                        new DeleteOptions { DeleteFileLocation = true },
+                        true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Could not delete orphaned collection '{CollectionName}'", orphan.Name);
+                }
+            }
         }
 
         // ================================================================
@@ -1220,6 +1293,7 @@ namespace Jellyfin.Plugin.AutoCollections
                 Configuration.MatchType.Actor => "actor",
                 Configuration.MatchType.Director => "director",
                 Configuration.MatchType.Tag => "tag",
+                Configuration.MatchType.Writer => "writer",
                 _ => "title"
             };
             
@@ -1380,6 +1454,7 @@ namespace Jellyfin.Plugin.AutoCollections
             _personToMoviesCache = new Dictionary<(string, string, bool), HashSet<Guid>>();
             _personToSeriesCache = new Dictionary<(string, string, bool), HashSet<Guid>>();
             _itemPeopleCache = new Dictionary<Guid, List<(string Name, string Type)>>();
+            _itemLibrariesCache = new Dictionary<Guid, List<string>>();
         }
         
         // Clear person-to-media cache after expression evaluation is complete
@@ -1388,6 +1463,7 @@ namespace Jellyfin.Plugin.AutoCollections
             _personToMoviesCache = null;
             _personToSeriesCache = null;
             _itemPeopleCache = null;
+            _itemLibrariesCache = null;
         }
         
         // Get cached people for an item (movie or series)
@@ -1700,6 +1776,36 @@ namespace Jellyfin.Plugin.AutoCollections
                     // Check if the movie is watched (played by at least one user)
                     return IsItemUnplayed(movie) == false;
                     
+                case Configuration.CriteriaType.Library:
+                    return MatchesLibrary(movie, value, comparison);
+
+                case Configuration.CriteriaType.Runtime:
+                    return MatchesRuntime(movie, value);
+
+                case Configuration.CriteriaType.Resolution:
+                    return MatchesResolution(movie, value);
+
+                case Configuration.CriteriaType.VideoRange:
+                    return MatchesVideoRange(movie, value);
+
+                case Configuration.CriteriaType.AudioChannels:
+                    return MatchesAudioChannels(movie, value);
+
+                case Configuration.CriteriaType.AudioCodec:
+                    return MatchesAudioCodec(movie, value, comparison);
+
+                case Configuration.CriteriaType.Writer:
+                    return MovieHasPerson(movie.Id, value, "Writer", caseSensitive);
+
+                case Configuration.CriteriaType.Producer:
+                    return MovieHasPerson(movie.Id, value, "Producer", caseSensitive);
+
+                case Configuration.CriteriaType.Overview:
+                    return !string.IsNullOrEmpty(movie.Overview) && movie.Overview.Contains(value, comparison);
+
+                case Configuration.CriteriaType.Tagline:
+                    return !string.IsNullOrEmpty(movie.Tagline) && movie.Tagline.Contains(value, comparison);
+
                 default:
                     return false;
             }
@@ -1855,6 +1961,36 @@ namespace Jellyfin.Plugin.AutoCollections
                     // Check if the series is watched (played by at least one user)
                     return IsItemUnplayed(series) == false;
                     
+                case Configuration.CriteriaType.Library:
+                    return MatchesLibrary(series, value, comparison);
+
+                case Configuration.CriteriaType.Runtime:
+                    return MatchesRuntime(series, value);
+
+                case Configuration.CriteriaType.Resolution:
+                    return MatchesResolution(series, value);
+
+                case Configuration.CriteriaType.VideoRange:
+                    return MatchesVideoRange(series, value);
+
+                case Configuration.CriteriaType.AudioChannels:
+                    return MatchesAudioChannels(series, value);
+
+                case Configuration.CriteriaType.AudioCodec:
+                    return MatchesAudioCodec(series, value, comparison);
+
+                case Configuration.CriteriaType.Writer:
+                    return SeriesHasPerson(series.Id, value, "Writer", caseSensitive);
+
+                case Configuration.CriteriaType.Producer:
+                    return SeriesHasPerson(series.Id, value, "Producer", caseSensitive);
+
+                case Configuration.CriteriaType.Overview:
+                    return !string.IsNullOrEmpty(series.Overview) && series.Overview.Contains(value, comparison);
+
+                case Configuration.CriteriaType.Tagline:
+                    return !string.IsNullOrEmpty(series.Tagline) && series.Tagline.Contains(value, comparison);
+
                 default:
                     return false;
             }
@@ -2200,6 +2336,198 @@ namespace Jellyfin.Plugin.AutoCollections
             return false;
         }
         
+        // ================================================================
+        // LIBRARY, TECHNICAL AND TEXT CRITERIA
+        // ================================================================
+        // Shared evaluation helpers. These behave identically for movies and
+        // series, so both criteria switches delegate here.
+
+        /// <summary>
+        /// Names of the libraries (media folders) an item belongs to.
+        /// </summary>
+        private List<string> GetLibraryNames(BaseItem item)
+        {
+            if (_itemLibrariesCache != null && _itemLibrariesCache.TryGetValue(item.Id, out var cached))
+            {
+                return cached;
+            }
+
+            List<string> names;
+            try
+            {
+                names = _libraryManager.GetCollectionFolders(item)
+                    .Select(folder => folder.Name)
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not determine the library for item {ItemName}", item.Name);
+                names = new List<string>();
+            }
+
+            if (_itemLibrariesCache != null)
+            {
+                _itemLibrariesCache[item.Id] = names;
+            }
+
+            return names;
+        }
+
+        private bool MatchesLibrary(BaseItem item, string value, StringComparison comparison)
+        {
+            return GetLibraryNames(item).Any(name => name.Equals(value, comparison));
+        }
+
+        /// <summary>
+        /// Compares the item's runtime, in whole minutes, against a value such as "&lt;45" or "&gt;=100".
+        /// </summary>
+        private bool MatchesRuntime(BaseItem item, string value)
+        {
+            if (!item.RunTimeTicks.HasValue || item.RunTimeTicks.Value <= 0)
+            {
+                return false;
+            }
+
+            var minutes = (float)item.RunTimeTicks.Value / TimeSpan.TicksPerMinute;
+            return CompareNumericValue(minutes, value);
+        }
+
+        private MediaBrowser.Model.Entities.MediaStream? GetPrimaryVideoStream(BaseItem item)
+        {
+            return item.GetMediaStreams()
+                .Where(stream => stream.Type == MediaBrowser.Model.Entities.MediaStreamType.Video)
+                .OrderByDescending(stream => stream.Width ?? 0)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Matches a resolution label (4K, 1080p, 720p, SD) against the item's video stream.
+        /// </summary>
+        /// <remarks>
+        /// Buckets are based on width with a height fallback, because anamorphic and
+        /// non-16:9 sources do not line up with the nominal "1080p"-style heights.
+        /// </remarks>
+        private bool MatchesResolution(BaseItem item, string value)
+        {
+            var video = GetPrimaryVideoStream(item);
+            if (video == null)
+            {
+                return false;
+            }
+
+            var width = video.Width ?? 0;
+            var height = video.Height ?? 0;
+            if (width == 0 && height == 0)
+            {
+                return false;
+            }
+
+            string bucket;
+            if (width >= 3800 || height >= 2000)
+            {
+                bucket = "4K";
+            }
+            else if (width >= 2500 || height >= 1400)
+            {
+                bucket = "1440P";
+            }
+            else if (width >= 1800 || height >= 1000)
+            {
+                bucket = "1080P";
+            }
+            else if (width >= 1200 || height >= 700)
+            {
+                bucket = "720P";
+            }
+            else
+            {
+                bucket = "SD";
+            }
+
+            var wanted = value.Trim().ToUpperInvariant() switch
+            {
+                "4K" or "2160P" or "UHD" => "4K",
+                "1440P" or "2K" or "QHD" => "1440P",
+                "1080P" or "FHD" or "FULLHD" => "1080P",
+                "720P" or "HD" => "720P",
+                "SD" or "480P" or "576P" or "DVD" => "SD",
+                _ => value.Trim().ToUpperInvariant()
+            };
+
+            return bucket == wanted;
+        }
+
+        /// <summary>
+        /// Matches a dynamic range label (SDR, HDR, HDR10, HLG, DoVi) against the item's video stream.
+        /// </summary>
+        private bool MatchesVideoRange(BaseItem item, string value)
+        {
+            var video = GetPrimaryVideoStream(item);
+            if (video == null)
+            {
+                return false;
+            }
+
+            var rangeType = video.VideoRangeType.ToString().ToUpperInvariant();
+            var wanted = value.Trim().ToUpperInvariant();
+
+            return wanted switch
+            {
+                // "HDR" is the umbrella term users reach for, so it covers every
+                // high-dynamic-range flavour rather than only the HDR10 profile.
+                "HDR" => rangeType != "SDR" && rangeType != "UNKNOWN",
+                "SDR" => rangeType == "SDR",
+                "DOVI" or "DV" or "DOLBYVISION" => rangeType.StartsWith("DOVI", StringComparison.Ordinal),
+                _ => rangeType == wanted
+            };
+        }
+
+        /// <summary>
+        /// Compares the highest audio channel count against a value such as "&gt;=6", "5.1" or "stereo".
+        /// </summary>
+        private bool MatchesAudioChannels(BaseItem item, string value)
+        {
+            var channels = item.GetMediaStreams()
+                .Where(stream => stream.Type == MediaBrowser.Model.Entities.MediaStreamType.Audio)
+                .Select(stream => stream.Channels ?? 0)
+                .DefaultIfEmpty(0)
+                .Max();
+
+            if (channels == 0)
+            {
+                return false;
+            }
+
+            var wanted = value.Trim().ToUpperInvariant() switch
+            {
+                "MONO" => "1",
+                "STEREO" or "2.0" => "2",
+                "5.1" => "6",
+                "7.1" => "8",
+                _ => value.Trim()
+            };
+
+            return CompareNumericValue(channels, wanted);
+        }
+
+        /// <summary>
+        /// Matches an audio codec or track description, so both "dts" and "atmos" work.
+        /// </summary>
+        /// <remarks>
+        /// Atmos and similar are not codecs of their own; they only show up in the
+        /// stream's profile or display title, so both are searched.
+        /// </remarks>
+        private bool MatchesAudioCodec(BaseItem item, string value, StringComparison comparison)
+        {
+            return item.GetMediaStreams()
+                .Where(stream => stream.Type == MediaBrowser.Model.Entities.MediaStreamType.Audio)
+                .Any(stream =>
+                    (!string.IsNullOrEmpty(stream.Codec) && stream.Codec.Contains(value, comparison)) ||
+                    (!string.IsNullOrEmpty(stream.Profile) && stream.Profile.Contains(value, comparison)) ||
+                    (!string.IsNullOrEmpty(stream.DisplayTitle) && stream.DisplayTitle.Contains(value, comparison)));
+        }
+
         // Helper method to check if an item is unplayed (not watched by any user).
         // Returns null when the play state cannot be determined - callers must then treat
         // both UNPLAYED and WATCHED as "no match" rather than guessing, otherwise an

--- a/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
@@ -29,7 +29,17 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         EpisodeAirDate = 18, // Match by most recent episode air date (for TV shows)
         Unplayed = 19,  // Match unplayed items (not watched by any user)
         Watched = 20,   // Match watched items (played by at least one user)
-        Filename = 21   // Match by filename
+        Filename = 21,  // Match by filename
+        Library = 22,   // Match by library (media folder) name
+        Runtime = 23,   // Match by runtime in minutes
+        Resolution = 24, // Match by video resolution (SD, 720p, 1080p, 4K)
+        VideoRange = 25, // Match by dynamic range (SDR, HDR, HDR10, HLG, DoVi)
+        AudioChannels = 26, // Match by audio channel count (2, 6, 8)
+        AudioCodec = 27, // Match by audio codec or track title (dts, truehd, atmos)
+        Writer = 28,    // Match by writer
+        Producer = 29,  // Match by producer
+        Overview = 30,  // Match by overview / description text
+        Tagline = 31    // Match by tagline
     }
 
     // Token types for expression parsing
@@ -463,6 +473,25 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
                     continue;
                 }
 
+                // Library, technical and crew criteria. TryMatchCriteria requires a word
+                // boundary after the keyword, so longer keywords sharing a prefix with
+                // shorter ones (AUDIOCHANNELS / CHANNELS) do not need a particular order.
+                var matchedExtra = false;
+                foreach (var keyword in AdditionalCriteriaKeywords)
+                {
+                    if (TryMatchCriteria(expression, ref position, keyword, out var extraToken))
+                    {
+                        tokens.Add(extraToken);
+                        matchedExtra = true;
+                        break;
+                    }
+                }
+
+                if (matchedExtra)
+                {
+                    continue;
+                }
+
                 // Check for parentheses
                 if (expression[position] == '(')
                 {
@@ -541,6 +570,22 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
 
             return false;
         }
+        // Keywords added after the original criteria set. Kept as a list so the tokenizer
+        // does not need another near-identical if-block per keyword.
+        private static readonly string[] AdditionalCriteriaKeywords =
+        {
+            "LIBRARY",
+            "RUNTIME", "DURATION", "LENGTH",
+            "RESOLUTION", "QUALITY",
+            "HDR", "VIDEORANGE", "DYNAMICRANGE",
+            "AUDIOCHANNELS", "CHANNELS",
+            "AUDIOCODEC", "ACODEC",
+            "WRITER",
+            "PRODUCER",
+            "OVERVIEW", "DESCRIPTION", "PLOT",
+            "TAGLINE"
+        };
+
         private bool TryMatchCriteria(string expression, ref int position, string criteria, out Token token)
         {
             token = null;
@@ -636,6 +681,45 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
                             break;
                         case "WATCHED":
                             token.CriteriaType = Configuration.CriteriaType.Watched;
+                            break;
+                        case "LIBRARY":
+                            token.CriteriaType = Configuration.CriteriaType.Library;
+                            break;
+                        case "RUNTIME":
+                        case "DURATION":
+                        case "LENGTH":
+                            token.CriteriaType = Configuration.CriteriaType.Runtime;
+                            break;
+                        case "RESOLUTION":
+                        case "QUALITY":
+                            token.CriteriaType = Configuration.CriteriaType.Resolution;
+                            break;
+                        case "HDR":
+                        case "VIDEORANGE":
+                        case "DYNAMICRANGE":
+                            token.CriteriaType = Configuration.CriteriaType.VideoRange;
+                            break;
+                        case "AUDIOCHANNELS":
+                        case "CHANNELS":
+                            token.CriteriaType = Configuration.CriteriaType.AudioChannels;
+                            break;
+                        case "AUDIOCODEC":
+                        case "ACODEC":
+                            token.CriteriaType = Configuration.CriteriaType.AudioCodec;
+                            break;
+                        case "WRITER":
+                            token.CriteriaType = Configuration.CriteriaType.Writer;
+                            break;
+                        case "PRODUCER":
+                            token.CriteriaType = Configuration.CriteriaType.Producer;
+                            break;
+                        case "OVERVIEW":
+                        case "DESCRIPTION":
+                        case "PLOT":
+                            token.CriteriaType = Configuration.CriteriaType.Overview;
+                            break;
+                        case "TAGLINE":
+                            token.CriteriaType = Configuration.CriteriaType.Tagline;
                             break;
                     }
 

--- a/Jellyfin.Plugin.AutoCollections/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/PluginConfiguration.cs
@@ -65,7 +65,8 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         Studio = 2,  // Match by studio
         Actor = 3,   // Match by actor
         Director = 4, // Match by director
-        Tag = 5      // Match by tag
+        Tag = 5,     // Match by tag
+        Writer = 6   // Match by writer
     }
     
     // Media types for filtering collections
@@ -115,6 +116,7 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
                 MatchType.Actor => $"{matchString} Acting",
                 MatchType.Director => $"{matchString} Directed",
                 MatchType.Tag => $"{matchString} Tagged",
+                MatchType.Writer => $"{matchString} Written",
                 _ => $"{matchString} Movies" // Default for Title and any future types
             };
         }
@@ -134,6 +136,9 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
             
             // Flag to track if configuration has been initialized to prevent resetting user's intentional empty collections
             IsInitialized = false;
+
+            // Off by default: it deletes collections
+            DeleteOrphanedCollections = false;
         }
 
         public List<TitleMatchPair> TitleMatchPairs { get; set; }
@@ -144,6 +149,11 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         // Flag to indicate whether the configuration has been properly initialized
         // This prevents resetting the config when users intentionally have empty TitleMatchPairs
         public bool IsInitialized { get; set; }
+
+        // When enabled, collections this plugin created are deleted once they are
+        // removed from the configuration. Only collections carrying the plugin's own
+        // tag are ever considered.
+        public bool DeleteOrphanedCollections { get; set; }
         
         // Keep these for backward compatibility but they won't be used
         [Obsolete("Use TitleMatchPairs instead")]

--- a/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
@@ -163,6 +163,22 @@
               </button>
               
               <br />
+              <div class="checkboxContainer">
+                <label class="emby-checkbox-label">
+                  <input
+                    id="delete-orphaned-collections"
+                    is="emby-checkbox"
+                    type="checkbox"
+                  />
+                  <span>Delete collections when they are removed from this configuration</span>
+                </label>
+                <div class="fieldDescription">
+                  Only affects collections created by this plugin. Collections you made yourself,
+                  or that came from another plugin, are never touched. Off by default.
+                </div>
+              </div>
+
+              <br />
               <button
                 id="saveConfiguration"
                 is="emby-button"
@@ -306,7 +322,8 @@
             { value: '2', text: 'Studio' },
             { value: '3', text: 'Actor' },
             { value: '4', text: 'Director' },
-            { value: '5', text: 'Tag' }
+            { value: '5', text: 'Tag' },
+            { value: '6', text: 'Writer' }
           ];
           
           options.forEach(opt => {
@@ -484,6 +501,9 @@
             "06ebf4a9-1326-4327-968d-8da00e1ea2eb"
           ) // Plugin Id
             .then(function (config) {
+              document.querySelector("#delete-orphaned-collections").checked =
+                config.DeleteOrphanedCollections === true;
+
               // Load simple collections
               const titleMatchPairsContainer = document.querySelector("#title-match-pairs");
               titleMatchPairsContainer.innerHTML = '';
@@ -692,6 +712,7 @@
             TitleMatchPairs: titleMatchPairs,
             ExpressionCollections: expressionCollections,
             IsInitialized: true, // Mark as initialized to prevent defaults from being re-added
+            DeleteOrphanedCollections: document.querySelector("#delete-orphaned-collections").checked,
             // Keep these empty for backward compatibility
             TagTitlePairs: [],
             Tags: []

--- a/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
+++ b/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <AssemblyVersion>0.0.5.0</AssemblyVersion>
-    <FileVersion>0.0.5.0</FileVersion>
+    <AssemblyVersion>0.0.6.0</AssemblyVersion>
+    <FileVersion>0.0.6.0</FileVersion>
     <Authors />
     <Company />
     <RootNamespace>Jellyfin.Plugin.AutoCollections</RootNamespace>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := 0.0.5.0
+export VERSION := 0.0.6.0
 export GITHUB_REPO := KeksBombe/jellyfin-plugin-auto-collections
 export FILE := auto-collections-${VERSION}.zip
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ The Auto Collections plugin enables you to create smart collections that automat
 - **Studio**: Collect content from specific studios
 - **Actor**: Find all content featuring specific actors
 - **Director**: Group content by director
+- **Writer**: Group content by writer
+- **Producer**: Group content by producer
 - **Tag**: Match items with specific tags - uses exact matching
+- **Overview / Tagline**: Match words in the description or tagline
 - **Production Location**: Filter by country/region of origin
+- **Library**: Restrict a collection to one library (media folder)
 
 #### Media Type Filtering
 - **Movie**: Include only movies
@@ -50,6 +54,11 @@ The Auto Collections plugin enables you to create smart collections that automat
 #### Technical Criteria
 - **Audio Language**: Match content by audio track language
 - **Subtitle Language**: Filter by available subtitle languages
+- **Resolution**: Match by video resolution (4K, 1080p, 720p, SD)
+- **Dynamic Range**: Match by HDR, HDR10, HLG, Dolby Vision or SDR
+- **Audio Channels**: Match by channel count (stereo, 5.1, 7.1)
+- **Audio Codec**: Match by codec or track description (DTS, TrueHD, Atmos)
+- **Runtime**: Match by duration in minutes
 - **Year**: Match by production/release year
 - **Release Date**: Filter by release date with day-based comparisons
 - **Added Date**: Match by date added to library
@@ -78,7 +87,11 @@ Here are the REAL keywords you can use in expressions:
 - `STUDIO` - Match by studio
 - `ACTOR` - Match by actor
 - `DIRECTOR` - Match by director
+- `WRITER` - Match by writer
+- `PRODUCER` - Match by producer
 - `TAG` - Match by tag (exact match)
+- `OVERVIEW` / `DESCRIPTION` / `PLOT` - Match words in the description
+- `TAGLINE` - Match words in the tagline
 
 **Media Type Criteria:**
 - `MOVIE` - Match only movies
@@ -94,6 +107,18 @@ Here are the REAL keywords you can use in expressions:
 - `PRODUCTIONLOCATION` / `LOCATION` / `COUNTRY` - Match by production location
 - `LANG` - Match by audio language
 - `SUB` - Match by subtitle language
+- `LIBRARY` - Match by library (media folder) name, exact match
+
+**Quality Criteria:**
+
+These read the item's media streams. TV series carry no streams on the series itself, so
+like `LANG` and `SUB` these match movies; use them with `MOVIE` to be explicit.
+
+- `RESOLUTION` / `QUALITY` - `4K`, `1440p`, `1080p`, `720p`, `SD`
+- `HDR` / `VIDEORANGE` / `DYNAMICRANGE` - `SDR`, `HDR`, `HDR10`, `HLG`, `DOVI`
+- `AUDIOCHANNELS` / `CHANNELS` - channel count, or `stereo` / `5.1` / `7.1`
+- `AUDIOCODEC` / `ACODEC` - codec or track description, e.g. `dts`, `truehd`, `atmos`
+- `RUNTIME` / `DURATION` / `LENGTH` - runtime in minutes (supports comparisons)
 
 **Temporal Criteria:**
 - `YEAR` - Match by production year
@@ -121,10 +146,18 @@ Support for comparison operators in numeric fields:
 - `CUSTOMRATING "=7"` - Exactly 7
 
 #### Date-Based Filtering
-Day-based comparisons for temporal criteria:
-- `RELEASEDATE ">30"` - Released within last 30 days
-- `ADDEDDATE "<=7"` - Added to library within last 7 days
-- `EPISODEAIRDATE ">14"` - TV episodes aired within last 14 days
+Day-based comparisons for temporal criteria. The value is a **number of days ago**, so
+`<=` means recent and `>` means older:
+
+- `ADDEDDATE "<=7"` - Added to the library within the last 7 days
+- `ADDEDDATE "<=60"` - Added within roughly the last two months
+- `RELEASEDATE "<=1825"` - Released within roughly the last five years
+- `RELEASEDATE ">30"` - Released **more than** 30 days ago
+- `EPISODEAIRDATE "<=14"` - Newest episode aired within the last 14 days
+
+Because these are relative to the day the sync runs, such collections keep themselves
+current: items that stop matching are removed on the next run, so a "recently added"
+collection never needs editing by hand.
 
 ### 🤖 Automation Features
 
@@ -136,8 +169,10 @@ Day-based comparisons for temporal criteria:
 #### Collection Management
 - **Auto-Sorting**: Items sorted by production year and premiere date
 - **Deduplication**: Prevents duplicate entries in collections
-- **Image Assignment**: Automatically sets collection artwork from content
+- **Image Assignment**: Automatically sets collection artwork from content, and never replaces artwork you set yourself
 - **Smart Naming**: Intelligent default collection names based on criteria
+- **Name Protection**: Collections are locked so metadata providers cannot rename them or swap their artwork
+- **Orphan Cleanup** (optional, off by default): Delete collections once they are removed from the configuration. Only collections created by this plugin are ever removed
 
 ### 📊 Configuration Management
 
@@ -178,7 +213,7 @@ Day-based comparisons for temporal criteria:
 ### Simple Collections Setup
 
 1. Navigate to `Dashboard -> Plugins -> My Plugins -> Auto Collections`
-2. Choose match type: Title, Genre, Studio, Actor, Director, or Tag
+2. Choose match type: Title, Genre, Studio, Actor, Director, Writer, or Tag
 3. Set media type filter: All, Movies only, or Shows only
 4. Enter search string
 5. Configure case sensitivity
@@ -198,8 +233,13 @@ Day-based comparisons for temporal criteria:
      - `STUDIO "name"` - Match items from "name" studio
      - `ACTOR "name"` - Match items with "name" actor
      - `DIRECTOR "name"` - Match items with "name" director
+     - `WRITER "name"` - Match items with "name" writer
+     - `PRODUCER "name"` - Match items with "name" producer
      - `TAG "tag"` - Match items carrying exactly that tag (e.g., `TAG "Best Film"` does not match "Best Film Editing")
+     - `OVERVIEW "text"` / `DESCRIPTION "text"` / `PLOT "text"` - Match items whose description contains "text"
+     - `TAGLINE "text"` - Match items whose tagline contains "text"
      - `PRODUCTIONLOCATION "location"` / `LOCATION "location"` / `COUNTRY "location"` - Match items by production country/location
+     - `LIBRARY "name"` - Only include items from the library (media folder) called "name". Matches the whole name
 
      **Rating Filters:**
      - `PARENTALRATING "rating"` / `PARENTAL "rating"` / `RATING "rating"` - Match items with specific parental rating (exact match, e.g., "PG" matches only "PG", not "PG-13")
@@ -248,6 +288,21 @@ Day-based comparisons for temporal criteria:
 #### Play State Collections
 - `MOVIE AND UNPLAYED AND COMMUNITYRATING ">7.5"` - Unwatched high-rated movies
 - `SHOW AND WATCHED AND GENRE "Drama"` - Watched drama series
+
+#### Library Filtering
+- `TAG "Family" AND LIBRARY "Movies"` - Only from the "Movies" library, ignoring identical titles held in others
+- `LIBRARY "4K Movies" AND RESOLUTION "4K"` - Avoids pulling in the 1080p duplicate from another library
+
+#### Quality and Runtime
+- `RESOLUTION "4K" AND HDR "DOVI"` - Dolby Vision 4K content
+- `NOT RESOLUTION "4K"` - Everything a device that cannot handle 4K can play
+- `MOVIE AND RUNTIME "<45"` - Shorts
+- `MOVIE AND RUNTIME "<=100" AND GENRE "Comedy"` - Comedies you can finish in an evening
+- `CHANNELS ">=6" AND AUDIOCODEC "atmos"` - Atmos content with surround audio
+
+#### Crew and Text
+- `WRITER "George Carlin" AND TAG "Stand-Up"` - Specials written by a comedian, without their acting credits
+- `OVERVIEW "heist" OR TAGLINE "one last job"` - Matching words in the description rather than the tags
 
 ## 🔧 Configuration
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-auto-collections"
 guid: "06ebf4a9-1326-4327-968d-8da00e1ea2eb"
-version: "0.0.5.0" # Please increment with each pull request
+version: "0.0.6.0" # Please increment with each pull request
 jellyfin_version: "10.11.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Auto Collections"


### PR DESCRIPTION
Adds the filters that keep coming up, plus optional cleanup of collections you've removed from the config.

Closes #28, #99, #86, #36, #87, #71, #33, #104, #108, #83.

### New keywords

- `LIBRARY "name"` — only items from that library. The one people ask for most: #28 has four separate requests and #99 is the same thing again. Fixes a separate 4K library putting every film in twice, and lets per-language libraries stay apart.
- `RUNTIME` / `DURATION` / `LENGTH` — minutes, with comparisons. `MOVIE AND RUNTIME "<45"` for shorts.
- `RESOLUTION` / `QUALITY` — 4K, 1440p, 1080p, 720p, SD
- `HDR` / `VIDEORANGE` / `DYNAMICRANGE` — SDR, HDR, HDR10, HLG, DOVI
- `AUDIOCHANNELS` / `CHANNELS` — a number, or stereo / 5.1 / 7.1
- `AUDIOCODEC` / `ACODEC` — dts, truehd, atmos
- `WRITER`, `PRODUCER`
- `OVERVIEW` / `DESCRIPTION` / `PLOT`, `TAGLINE`

WRITER is in the simple collection dropdown as well, since #33 asked for both. It also sorts out the stand-up case in that issue — the comedian is credited as writer, so ACTOR was dragging in all their film roles.

A few calls I made in there. Resolution buckets go by width with a height fallback, because anamorphic sources don't line up with the nominal 1080p-style heights. `HDR "HDR"` matches any HDR flavour since that's how the word gets used; HDR10 and DOVI are exact if you want them. Atmos isn't a codec, so AUDIOCODEC checks the profile and track title too. All of these read media streams, and series don't have those at series level, so like LANG and SUB they're really movie filters — noted in the README.

### Deleting collections removed from the config

#83. I'd said this would need the plugin to remember what it created. It does now — 0.0.5.0 was where the Autocollection tag started actually getting saved, which is what makes colin715's suggestion in that thread work.

Off by default, with a checkbox and a short explanation on the config page. Only touches collections carrying our tag, so nothing made by hand or by another plugin. And it skips entirely when the config has no collections in it, so a config that fails to load can't wipe the lot.

### README date examples were wrong

`RELEASEDATE ">30"` was documented as "released within last 30 days". It's the opposite — the code does `now - releaseDate`, so that matches everything *older* than 30 days. ADDEDDATE's example was right, RELEASEDATE and EPISODEAIRDATE were both backwards.

That's almost certainly why #110 got opened asking for relative date filters that already existed. Fixed, and added the recent-items examples people were actually after.
