### PR TITLE
Per-collection sorting and a dry run preview (0.0.7.0)

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
+++ b/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
@@ -19,6 +19,19 @@ using System.Text.Encodings.Web;
 namespace Jellyfin.Plugin.AutoCollections.Api
 {
     /// <summary>
+    /// Body of a single-collection preview request. Exactly one of the two is used.
+    /// </summary>
+    /// <remarks>
+    /// The properties deliberately do not share their types' names: the ASP.NET Core 2.2
+    /// TopLevelParameterNameAnalyzer crashes on that shape and fails the build with AD0001.
+    /// </remarks>
+    public class PreviewRequest
+    {
+        public TitleMatchPair Simple { get; set; }
+        public ExpressionCollection Advanced { get; set; }
+    }
+
+    /// <summary>
     /// The Auto Collections api controller.
     /// </summary>
     [ApiController]
@@ -86,6 +99,49 @@ namespace Jellyfin.Plugin.AutoCollections.Api
             return Accepted();
         }
         
+        /// <summary>
+        /// Works out what a sync would do to a single collection, without changing anything.
+        /// </summary>
+        /// <remarks>
+        /// The collection is posted in the request body rather than read from the saved
+        /// configuration, so a rule can be checked before it is saved - which is the point,
+        /// since saving it lets the scheduled task act on it.
+        /// </remarks>
+        /// <response code="200">The preview result.</response>
+        /// <response code="400">Neither a simple nor an advanced collection was supplied.</response>
+        [HttpPost("Preview")]
+        [Consumes("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public ActionResult<CollectionPreview> Preview([FromBody] PreviewRequest request)
+        {
+            if (request?.Advanced != null)
+            {
+                return Ok(_syncAutoCollectionsManager.PreviewExpressionCollection(request.Advanced));
+            }
+
+            if (request?.Simple != null)
+            {
+                return Ok(_syncAutoCollectionsManager.PreviewTitleMatchPair(request.Simple));
+            }
+
+            return BadRequest(new { Message = "Supply either a Simple or an Advanced collection" });
+        }
+
+        /// <summary>
+        /// Works out what a sync would do to every collection in the supplied configuration.
+        /// </summary>
+        /// <response code="200">One preview result per collection.</response>
+        [HttpPost("PreviewAll")]
+        [Consumes("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public ActionResult<List<CollectionPreview>> PreviewAll([FromBody] PluginConfiguration configuration)
+        {
+            // Falls back to the saved configuration when the page sends nothing.
+            var toPreview = configuration ?? Plugin.Instance!.Configuration;
+            return Ok(_syncAutoCollectionsManager.PreviewConfiguration(toPreview));
+        }
+
         /// <summary>
         /// Exports the Auto Collections configuration to JSON.
         /// </summary>

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -22,13 +22,6 @@ using Jellyfin.Plugin.AutoCollections.Configuration;
 
 namespace Jellyfin.Plugin.AutoCollections
 {
-    // Internal enum for sort order
-    internal enum SortOrder
-    {
-        Ascending,
-        Descending
-    }
-    
     // ================================================================
     // CLASS DECLARATION AND DEPENDENCY INJECTION
     // ================================================================
@@ -252,7 +245,7 @@ namespace Jellyfin.Plugin.AutoCollections
         // ================================================================
         // This section contains methods that work with both movies and series,
         // providing generic search functionality based on match types and patterns.
-        private IEnumerable<Movie> GetMoviesFromLibraryByMatch(string matchString, bool caseSensitive, Configuration.MatchType matchType)
+        private IEnumerable<Movie> GetMoviesFromLibraryByMatch(string matchString, bool caseSensitive, Configuration.MatchType matchType, bool exactMatch = false)
         {
             // Get all non-null movies from the library
             var allMovies = _libraryManager.GetItemList(new InternalItemsQuery
@@ -265,36 +258,39 @@ namespace Jellyfin.Plugin.AutoCollections
             StringComparison comparison = caseSensitive 
                 ? StringComparison.Ordinal 
                 : StringComparison.OrdinalIgnoreCase;
+
+            // With exact matching the search string has to be the whole value rather than
+            // appear somewhere inside it.
+            bool Matches(string? candidate) =>
+                !string.IsNullOrEmpty(candidate) && (exactMatch
+                    ? candidate.Equals(matchString, comparison)
+                    : candidate.Contains(matchString, comparison));
             
             // Filter movies based on match type
             return matchType switch
             {
-                Configuration.MatchType.Title => allMovies.Where(movie => 
-                    !string.IsNullOrEmpty(movie.Name) && movie.Name.Contains(matchString, comparison)),
+                Configuration.MatchType.Title => allMovies.Where(movie => Matches(movie.Name)),
                 
                 Configuration.MatchType.Genre => allMovies.Where(movie => 
-                    movie.Genres != null && movie.Genres.Any(genre => 
-                        !string.IsNullOrEmpty(genre) && genre.Contains(matchString, comparison))),
+                    movie.Genres != null && movie.Genres.Any(Matches)),
                 
                 Configuration.MatchType.Studio => allMovies.Where(movie => 
-                    movie.Studios != null && movie.Studios.Any(studio => 
-                        !string.IsNullOrEmpty(studio) && studio.Contains(matchString, comparison))),
+                    movie.Studios != null && movie.Studios.Any(Matches)),
                 
-                Configuration.MatchType.Actor => GetMoviesWithPerson(matchString, "Actor", caseSensitive),
+                Configuration.MatchType.Actor => GetMoviesWithPerson(matchString, "Actor", caseSensitive, exactMatch),
                 
-                Configuration.MatchType.Director => GetMoviesWithPerson(matchString, "Director", caseSensitive),
+                Configuration.MatchType.Director => GetMoviesWithPerson(matchString, "Director", caseSensitive, exactMatch),
                 
                 Configuration.MatchType.Tag => allMovies.Where(movie => 
                     movie.Tags != null && movie.Tags.Any(tag => 
                         !string.IsNullOrEmpty(tag) && tag.Equals(matchString, comparison))),
                 
-                Configuration.MatchType.Writer => GetMoviesWithPerson(matchString, "Writer", caseSensitive),
+                Configuration.MatchType.Writer => GetMoviesWithPerson(matchString, "Writer", caseSensitive, exactMatch),
                 
-                _ => allMovies.Where(movie => 
-                    !string.IsNullOrEmpty(movie.Name) && movie.Name.Contains(matchString, comparison))
+                _ => allMovies.Where(movie => Matches(movie.Name))
             };
         }
-          private IEnumerable<Series> GetSeriesFromLibraryByMatch(string matchString, bool caseSensitive, Configuration.MatchType matchType)
+          private IEnumerable<Series> GetSeriesFromLibraryByMatch(string matchString, bool caseSensitive, Configuration.MatchType matchType, bool exactMatch = false)
                 {
                     // Get all series from the library
                     var allSeries = _libraryManager.GetItemList(new InternalItemsQuery
@@ -306,34 +302,37 @@ namespace Jellyfin.Plugin.AutoCollections
                     
                     StringComparison comparison = caseSensitive 
                         ? StringComparison.Ordinal 
-                        : StringComparison.OrdinalIgnoreCase;              // Filter series based on match type
+                        : StringComparison.OrdinalIgnoreCase;
+
+                    bool Matches(string? candidate) =>
+                        !string.IsNullOrEmpty(candidate) && (exactMatch
+                            ? candidate.Equals(matchString, comparison)
+                            : candidate.Contains(matchString, comparison));
+
+                    // Filter series based on match type
                     return matchType switch
                     {
-                        Configuration.MatchType.Title => allSeries.Where(series => 
-                            series.Name != null && series.Name.Contains(matchString, comparison)),
+                        Configuration.MatchType.Title => allSeries.Where(series => Matches(series.Name)),
                         
                         Configuration.MatchType.Genre => allSeries.Where(series => 
-                            series.Genres != null && series.Genres.Any(genre => 
-                                genre.Contains(matchString, comparison))),
+                            series.Genres != null && series.Genres.Any(Matches)),
                         
                         Configuration.MatchType.Studio => allSeries.Where(series => 
-                            series.Studios != null && series.Studios.Any(studio => 
-                                studio.Contains(matchString, comparison))),
+                            series.Studios != null && series.Studios.Any(Matches)),
                         
                         // Use GetSeriesWithPerson which properly verifies the person's role in each series
-                        Configuration.MatchType.Actor => GetSeriesWithPerson(matchString, "Actor", caseSensitive),
+                        Configuration.MatchType.Actor => GetSeriesWithPerson(matchString, "Actor", caseSensitive, exactMatch),
                         
                         // Use GetSeriesWithPerson which properly verifies the person's role in each series
-                        Configuration.MatchType.Director => GetSeriesWithPerson(matchString, "Director", caseSensitive),
+                        Configuration.MatchType.Director => GetSeriesWithPerson(matchString, "Director", caseSensitive, exactMatch),
                         
                         Configuration.MatchType.Tag => allSeries.Where(series => 
                             series.Tags != null && series.Tags.Any(tag => 
                                 !string.IsNullOrEmpty(tag) && tag.Equals(matchString, comparison))),
                         
-                        Configuration.MatchType.Writer => GetSeriesWithPerson(matchString, "Writer", caseSensitive),
+                        Configuration.MatchType.Writer => GetSeriesWithPerson(matchString, "Writer", caseSensitive, exactMatch),
                         
-                        _ => allSeries.Where(series => 
-                            series.Name != null && series.Name.Contains(matchString, comparison)) // Default to title match
+                        _ => allSeries.Where(series => Matches(series.Name)) // Default to title match
                     };
                 }
           // Keep these for backward compatibility
@@ -385,7 +384,11 @@ namespace Jellyfin.Plugin.AutoCollections
             }
         }
 
-        private async Task AddWantedMediaItems(BoxSet collection, IEnumerable<BaseItem> wantedMediaItems)
+        private async Task AddWantedMediaItems(
+            BoxSet collection,
+            IEnumerable<BaseItem> wantedMediaItems,
+            Configuration.CollectionSortBy sortBy = Configuration.CollectionSortBy.ReleaseYear,
+            Configuration.CollectionSortOrder sortOrder = Configuration.CollectionSortOrder.Descending)
         {
             // Get the set of IDs for items currently in the collection
             var existingItemIds = collection.GetLinkedChildren()
@@ -393,11 +396,12 @@ namespace Jellyfin.Plugin.AutoCollections
                 .ToHashSet();            
 
             // Create LinkedChild objects for items that aren't already in the collection
-            var itemsToAdd = wantedMediaItems
-                .Where(item => !existingItemIds.Contains(item.Id))
-                .OrderByDescending(item => item.ProductionYear)
-                .ThenByDescending(item => item.PremiereDate ?? DateTime.MinValue)
-                .ToList();
+            // Inserted in the collection's own order so the stored order is already right for
+            // the sorts Jellyfin cannot do itself.
+            var itemsToAdd = ApplySortOrder(
+                wantedMediaItems.Where(item => !existingItemIds.Contains(item.Id)),
+                sortBy,
+                sortOrder);
 
             if (itemsToAdd.Count > 0)
             {
@@ -424,8 +428,99 @@ namespace Jellyfin.Plugin.AutoCollections
             }
         }
 
-        private async Task SortCollectionBy(BoxSet collection, SortOrder sortOrder)
+        /// <summary>
+        /// The <see cref="ItemSortBy"/> name Jellyfin understands for a sort field, or null when
+        /// the plugin has to order the items itself.
+        /// </summary>
+        private static string? GetNativeDisplayOrder(Configuration.CollectionSortBy sortBy)
         {
+            return sortBy switch
+            {
+                Configuration.CollectionSortBy.ReleaseYear => "PremiereDate",
+                Configuration.CollectionSortBy.DateAdded => "DateCreated",
+                Configuration.CollectionSortBy.Name => "SortName",
+                Configuration.CollectionSortBy.CommunityRating => "CommunityRating",
+                Configuration.CollectionSortBy.Runtime => "Runtime",
+                Configuration.CollectionSortBy.Random => "Random",
+                _ => null
+            };
+        }
+
+        /// <summary>
+        /// Decides how a collection's order is applied.
+        /// </summary>
+        /// <remarks>
+        /// Jellyfin sorts a BoxSet by its DisplayOrder field, but always ascending
+        /// (see BoxSet.Sort). So ascending orders are handed to Jellyfin, which costs nothing
+        /// and keeps working as the library changes, while descending has to be produced here by
+        /// controlling the order items are stored in - with DisplayOrder left on "Default", which
+        /// is the value that makes Jellyfin return them untouched. Random is inherently
+        /// orderless, so it always goes to Jellyfin.
+        /// </remarks>
+        private static bool UsesNativeSorting(Configuration.CollectionSortBy sortBy, Configuration.CollectionSortOrder sortOrder)
+        {
+            if (sortBy == Configuration.CollectionSortBy.Random)
+            {
+                return true;
+            }
+
+            return sortOrder == Configuration.CollectionSortOrder.Ascending
+                && GetNativeDisplayOrder(sortBy) != null;
+        }
+
+        private static string GetDisplayOrderValue(Configuration.CollectionSortBy sortBy, Configuration.CollectionSortOrder sortOrder)
+        {
+            return UsesNativeSorting(sortBy, sortOrder)
+                ? GetNativeDisplayOrder(sortBy) ?? "Default"
+                : "Default";
+        }
+
+        /// <summary>
+        /// Orders items the way the collection is configured, for the cases Jellyfin cannot do itself.
+        /// </summary>
+        private static List<BaseItem> ApplySortOrder(
+            IEnumerable<BaseItem> items,
+            Configuration.CollectionSortBy sortBy,
+            Configuration.CollectionSortOrder sortOrder)
+        {
+            var descending = sortOrder == Configuration.CollectionSortOrder.Descending;
+
+            IOrderedEnumerable<BaseItem> ordered = sortBy switch
+            {
+                Configuration.CollectionSortBy.DateAdded => descending
+                    ? items.OrderByDescending(item => item.DateCreated)
+                    : items.OrderBy(item => item.DateCreated),
+                Configuration.CollectionSortBy.Name => descending
+                    ? items.OrderByDescending(item => item.SortName ?? item.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                    : items.OrderBy(item => item.SortName ?? item.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase),
+                Configuration.CollectionSortBy.CommunityRating => descending
+                    ? items.OrderByDescending(item => item.CommunityRating ?? 0f)
+                    : items.OrderBy(item => item.CommunityRating ?? 0f),
+                Configuration.CollectionSortBy.Runtime => descending
+                    ? items.OrderByDescending(item => item.RunTimeTicks ?? 0L)
+                    : items.OrderBy(item => item.RunTimeTicks ?? 0L),
+                _ => descending
+                    ? items.OrderByDescending(item => item.ProductionYear)
+                        .ThenByDescending(item => item.PremiereDate ?? DateTime.MinValue)
+                    : items.OrderBy(item => item.ProductionYear)
+                        .ThenBy(item => item.PremiereDate ?? DateTime.MinValue)
+            };
+
+            // Tie-break on id so a given set of items always lands in the same order
+            return ordered.ThenBy(item => item.Id).ToList();
+        }
+
+        private async Task SortCollectionBy(
+            BoxSet collection,
+            Configuration.CollectionSortBy sortBy,
+            Configuration.CollectionSortOrder sortOrder)
+        {
+            if (UsesNativeSorting(sortBy, sortOrder))
+            {
+                // Jellyfin orders these on read, so there is nothing to rearrange here.
+                return;
+            }
+
             // Get the current items in the collection
             var currentItems = collection.GetLinkedChildren().ToList();
 
@@ -435,17 +530,7 @@ namespace Jellyfin.Plugin.AutoCollections
                 return;
             }
 
-            // Sort the items based on the sort order
-            var sortedItems =
-                sortOrder == SortOrder.Ascending
-                    ? currentItems
-                        .OrderBy(item => item.ProductionYear)
-                        .ThenBy(item => item.PremiereDate ?? DateTime.MinValue)
-                        .ToList()
-                    : currentItems
-                        .OrderByDescending(item => item.ProductionYear)
-                        .ThenByDescending(item => item.PremiereDate ?? DateTime.MinValue)
-                        .ToList();
+            var sortedItems = ApplySortOrder(currentItems, sortBy, sortOrder);
 
             // Find the first index where items differ
             int firstDifferenceIndex = -1;
@@ -640,7 +725,10 @@ namespace Jellyfin.Plugin.AutoCollections
         /// Fetches the collection for <paramref name="collectionName"/>, creating it when missing,
         /// and makes sure the plugin's ownership tag and metadata locks are actually persisted.
         /// </summary>
-        private async Task<(BoxSet Collection, bool IsNew)> GetOrCreateCollectionAsync(string collectionName)
+        private async Task<(BoxSet Collection, bool IsNew)> GetOrCreateCollectionAsync(
+            string collectionName,
+            Configuration.CollectionSortBy sortBy = Configuration.CollectionSortBy.ReleaseYear,
+            Configuration.CollectionSortOrder sortOrder = Configuration.CollectionSortOrder.Descending)
         {
             var collection = GetBoxSetByName(collectionName);
             var isNew = false;
@@ -656,7 +744,7 @@ namespace Jellyfin.Plugin.AutoCollections
                 isNew = true;
             }
 
-            await ApplyCollectionMetadataAsync(collection, collectionName);
+            await ApplyCollectionMetadataAsync(collection, collectionName, sortBy, sortOrder);
             return (collection, isNew);
         }
 
@@ -671,7 +759,11 @@ namespace Jellyfin.Plugin.AutoCollections
         /// and - because the plugin could no longer find the renamed collection - create a
         /// replacement on the next run while the old one was cleaned up.
         /// </remarks>
-        private async Task ApplyCollectionMetadataAsync(BoxSet collection, string collectionName)
+        private async Task ApplyCollectionMetadataAsync(
+            BoxSet collection,
+            string collectionName,
+            Configuration.CollectionSortBy sortBy = Configuration.CollectionSortBy.ReleaseYear,
+            Configuration.CollectionSortOrder sortOrder = Configuration.CollectionSortOrder.Descending)
         {
             var changed = false;
 
@@ -711,9 +803,10 @@ namespace Jellyfin.Plugin.AutoCollections
                 changed = true;
             }
 
-            if (!string.Equals(collection.DisplayOrder, "Default", StringComparison.Ordinal))
+            var displayOrder = GetDisplayOrderValue(sortBy, sortOrder);
+            if (!string.Equals(collection.DisplayOrder, displayOrder, StringComparison.Ordinal))
             {
-                collection.DisplayOrder = "Default";
+                collection.DisplayOrder = displayOrder;
                 changed = true;
             }
 
@@ -727,6 +820,173 @@ namespace Jellyfin.Plugin.AutoCollections
                 collection.GetParent(),
                 ItemUpdateType.MetadataEdit,
                 CancellationToken.None).ConfigureAwait(true);
+        }
+
+        // ================================================================
+        // PREVIEW METHODS
+        // ================================================================
+        // Read-only evaluation used by the dry run. Nothing here writes to the
+        // library, so a preview is safe to run at any time, including during a sync.
+
+        // Long lists are pointless to render and expensive to ship, so each side is capped.
+        private const int MaxPreviewItems = 200;
+
+        /// <summary>
+        /// Works out what a sync would do to the collection for <paramref name="titleMatchPair"/>.
+        /// </summary>
+        public CollectionPreview PreviewTitleMatchPair(TitleMatchPair titleMatchPair)
+        {
+            var matched = GetMatchingItemsForTitleMatchPair(titleMatchPair);
+            return BuildPreview(titleMatchPair.CollectionName, matched, null);
+        }
+
+        /// <summary>
+        /// Works out what a sync would do to the collection for <paramref name="expressionCollection"/>.
+        /// </summary>
+        public CollectionPreview PreviewExpressionCollection(Configuration.ExpressionCollection expressionCollection)
+        {
+            if (!expressionCollection.ParseExpression())
+            {
+                return new CollectionPreview
+                {
+                    CollectionName = expressionCollection.CollectionName,
+                    CollectionExists = GetBoxSetByName(expressionCollection.CollectionName) != null,
+                    Errors = expressionCollection.ParseErrors.ToList()
+                };
+            }
+
+            var matched = GetMatchingItemsForExpressionCollection(expressionCollection);
+            return BuildPreview(expressionCollection.CollectionName, matched, expressionCollection.Expression);
+        }
+
+        /// <summary>
+        /// Previews every collection in a configuration.
+        /// </summary>
+        /// <remarks>
+        /// The person cache is opened once for the whole batch, the same way a real run does it,
+        /// so previewing everything costs about what one sync costs minus the writes.
+        /// </remarks>
+        public List<CollectionPreview> PreviewConfiguration(PluginConfiguration configuration)
+        {
+            var results = new List<CollectionPreview>();
+
+            InitializePersonCache();
+            try
+            {
+                foreach (var pair in configuration.TitleMatchPairs ?? new List<TitleMatchPair>())
+                {
+                    results.Add(PreviewTitleMatchPair(pair));
+                }
+
+                foreach (var expression in configuration.ExpressionCollections ?? new List<Configuration.ExpressionCollection>())
+                {
+                    results.Add(PreviewExpressionCollection(expression));
+                }
+            }
+            finally
+            {
+                ClearPersonCache();
+            }
+
+            return results;
+        }
+
+        private CollectionPreview BuildPreview(string collectionName, List<BaseItem> matchedItems, string? expression)
+        {
+            var collection = GetBoxSetByName(collectionName);
+            var current = collection?.GetLinkedChildren().ToList() ?? new List<BaseItem>();
+
+            var matchedIds = matchedItems.Select(i => i.Id).ToHashSet();
+            var currentIds = current.Select(i => i.Id).ToHashSet();
+
+            var added = matchedItems.Where(i => !currentIds.Contains(i.Id)).ToList();
+            var removed = current.Where(i => !matchedIds.Contains(i.Id)).ToList();
+
+            var preview = new CollectionPreview
+            {
+                CollectionName = collectionName,
+                CollectionExists = collection != null,
+                MatchedCount = matchedItems.Count,
+                CurrentCount = current.Count,
+                UnchangedCount = current.Count - removed.Count,
+                AddedCount = added.Count,
+                RemovedCount = removed.Count,
+                Added = added.Take(MaxPreviewItems).Select(ToPreviewItem).ToList(),
+                Removed = removed.Take(MaxPreviewItems).Select(ToPreviewItem).ToList(),
+                AddedTruncated = added.Count > MaxPreviewItems,
+                RemovedTruncated = removed.Count > MaxPreviewItems
+            };
+
+            preview.Warnings.AddRange(BuildWarnings(preview, expression));
+            return preview;
+        }
+
+        private static PreviewItem ToPreviewItem(BaseItem item)
+        {
+            return new PreviewItem
+            {
+                Name = item.Name ?? "(no title)",
+                Year = item.ProductionYear,
+                Type = item is Movie ? "Movie" : item is Series ? "Series" : "Item"
+            };
+        }
+
+        /// <summary>
+        /// Flags the shapes of result that usually mean the rule is not what the author intended.
+        /// </summary>
+        private List<string> BuildWarnings(CollectionPreview preview, string? expression)
+        {
+            var warnings = new List<string>();
+
+            if (preview.MatchedCount == 0)
+            {
+                warnings.Add(preview.CollectionExists && preview.CurrentCount > 0
+                    ? $"Nothing matches, so all {preview.CurrentCount} items currently in this collection would be removed"
+                    : "Nothing in the library matches this rule");
+            }
+            else if (preview.CollectionExists && preview.CurrentCount > 0 && preview.RemovedCount == preview.CurrentCount)
+            {
+                warnings.Add($"Every one of the {preview.CurrentCount} items currently in this collection would be replaced");
+            }
+            else if (preview.RemovedCount > 0 && preview.RemovedCount >= preview.CurrentCount / 2)
+            {
+                warnings.Add($"{preview.RemovedCount} of the {preview.CurrentCount} items currently in this collection would be removed");
+            }
+
+            var libraryTotal = GetLibraryItemCount();
+            if (libraryTotal > 0 && preview.MatchedCount > libraryTotal / 2)
+            {
+                warnings.Add($"Matches {preview.MatchedCount} of {libraryTotal} items in the library - check the rule is doing what you expect");
+            }
+
+            if (!string.IsNullOrEmpty(expression) &&
+                expression.Contains(" OR ", StringComparison.OrdinalIgnoreCase) &&
+                expression.Contains(" AND ", StringComparison.OrdinalIgnoreCase) &&
+                !expression.Contains('('))
+            {
+                warnings.Add("This mixes AND and OR without brackets. AND binds first, so add brackets if you meant otherwise");
+            }
+
+            return warnings;
+        }
+
+        private int _libraryItemCount = -1;
+
+        private int GetLibraryItemCount()
+        {
+            if (_libraryItemCount >= 0)
+            {
+                return _libraryItemCount;
+            }
+
+            _libraryItemCount = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Movie, BaseItemKind.Series },
+                IsVirtualItem = false,
+                Recursive = true
+            }).Count;
+
+            return _libraryItemCount;
         }
 
         // ================================================================
@@ -1251,8 +1511,8 @@ namespace Jellyfin.Plugin.AutoCollections
             var mediaItems = DedupeMediaItems(allMovies.Cast<BaseItem>().Concat(allSeries.Cast<BaseItem>()).ToList());
 
             await RemoveUnwantedMediaItems(collection, mediaItems);
-            await AddWantedMediaItems(collection, mediaItems);
-            await SortCollectionBy(collection, SortOrder.Descending);
+            await AddWantedMediaItems(collection, mediaItems, Configuration.CollectionSortBy.ReleaseYear, Configuration.CollectionSortOrder.Descending);
+            await SortCollectionBy(collection, Configuration.CollectionSortBy.ReleaseYear, Configuration.CollectionSortOrder.Descending);
             
             // Re-fetch the collection to get its updated children
             var updatedCollection = _libraryManager.GetItemById(collection.Id) as BoxSet;
@@ -1284,6 +1544,43 @@ namespace Jellyfin.Plugin.AutoCollections
         // ================================================================
         // This section contains methods for processing title match pairs and
         // creating collections based on pattern matching criteria.
+        /// <summary>
+        /// Resolves the items a simple collection should contain, without touching the collection.
+        /// </summary>
+        /// <remarks>Shared by the sync and by the preview endpoint, so both see the same result.</remarks>
+        private List<BaseItem> GetMatchingItemsForTitleMatchPair(TitleMatchPair titleMatchPair)
+        {
+            var allMovies = new List<Movie>();
+            var allSeries = new List<Series>();
+
+            var includeMovies = titleMatchPair.MediaType != Configuration.MediaTypeFilter.Series;
+            var includeSeries = titleMatchPair.MediaType != Configuration.MediaTypeFilter.Movies;
+
+            if (includeMovies)
+            {
+                allMovies = GetMoviesFromLibraryByMatch(
+                    titleMatchPair.TitleMatch,
+                    titleMatchPair.CaseSensitive,
+                    titleMatchPair.MatchType,
+                    titleMatchPair.ExactMatch).ToList();
+            }
+
+            if (includeSeries)
+            {
+                allSeries = GetSeriesFromLibraryByMatch(
+                    titleMatchPair.TitleMatch,
+                    titleMatchPair.CaseSensitive,
+                    titleMatchPair.MatchType,
+                    titleMatchPair.ExactMatch).ToList();
+            }
+
+            _logger.LogInformation(
+                "Found {MovieCount} movies and {SeriesCount} series matching '{Pattern}' for collection '{CollectionName}'",
+                allMovies.Count, allSeries.Count, titleMatchPair.TitleMatch, titleMatchPair.CollectionName);
+
+            return DedupeMediaItems(allMovies.Cast<BaseItem>().Concat(allSeries.Cast<BaseItem>()).ToList());
+        }
+
         private async Task ExecuteAutoCollectionsForTitleMatchPair(TitleMatchPair titleMatchPair)
         {            string matchTypeText = titleMatchPair.MatchType switch
             {
@@ -1311,90 +1608,16 @@ namespace Jellyfin.Plugin.AutoCollections
             var collectionName = titleMatchPair.CollectionName;
             
             // Get or create the collection
-            var (collection, isNewCollection) = await GetOrCreateCollectionAsync(collectionName);
+            var (collection, isNewCollection) = await GetOrCreateCollectionAsync(collectionName, titleMatchPair.SortBy, titleMatchPair.SortOrder);
               
             _logger.LogDebug("Title Match Collection '{CollectionName}' - Pattern: '{Pattern}', Match Type: {MatchType}, Case Sensitive: {CaseSensitive}", 
                 collectionName, titleMatchPair.TitleMatch, titleMatchPair.MatchType, titleMatchPair.CaseSensitive);
             
-            // Find all media items that match the pattern based on match type
-            List<Movie> allMovies = new();
-            List<Series> allSeries = new();
-            
-            // Apply media type filter
-            switch (titleMatchPair.MediaType)
-            {
-                case Configuration.MediaTypeFilter.Movies:
-                    // Only include movies
-                    _logger.LogDebug("Media filter: Movies only");
-                    allMovies = GetMoviesFromLibraryByMatch(
-                        titleMatchPair.TitleMatch, 
-                        titleMatchPair.CaseSensitive, 
-                        titleMatchPair.MatchType
-                    ).ToList();
-                    _logger.LogInformation($"Media filter: Movies only - found {allMovies.Count} matching items");
-                    
-                    foreach (var movie in allMovies)
-                    {
-                        var year = movie.ProductionYear?.ToString() ?? "Unknown year";
-                        _logger.LogDebug("  + Movie: '{Title}' ({Year})", movie.Name, year);
-                    }
-                    break;
-                    
-                case Configuration.MediaTypeFilter.Series:
-                    // Only include TV series
-                    _logger.LogDebug("Media filter: Series only");
-                    allSeries = GetSeriesFromLibraryByMatch(
-                        titleMatchPair.TitleMatch, 
-                        titleMatchPair.CaseSensitive, 
-                        titleMatchPair.MatchType
-                    ).ToList();
-                    _logger.LogInformation($"Media filter: Series only - found {allSeries.Count} matching items");
-                    
-                    foreach (var series in allSeries)
-                    {
-                        var year = series.ProductionYear?.ToString() ?? "Unknown year";
-                        _logger.LogDebug("  + Series: '{Title}' ({Year})", series.Name, year);
-                    }
-                    break;
-                    
-                case Configuration.MediaTypeFilter.All:
-                default:
-                    // Include both movies and series (default behavior)
-                    _logger.LogDebug("Media filter: All (movies and series)");
-                    allMovies = GetMoviesFromLibraryByMatch(
-                        titleMatchPair.TitleMatch, 
-                        titleMatchPair.CaseSensitive, 
-                        titleMatchPair.MatchType
-                    ).ToList();
-                    
-                    allSeries = GetSeriesFromLibraryByMatch(
-                        titleMatchPair.TitleMatch, 
-                        titleMatchPair.CaseSensitive, 
-                        titleMatchPair.MatchType
-                    ).ToList();
-                    _logger.LogInformation($"Media filter: All - found {allMovies.Count} movies and {allSeries.Count} series");
-                    
-                    foreach (var movie in allMovies)
-                    {
-                        var year = movie.ProductionYear?.ToString() ?? "Unknown year";
-                        _logger.LogDebug("  + Movie: '{Title}' ({Year})", movie.Name, year);
-                    }
-                    
-                    foreach (var series in allSeries)
-                    {
-                        var year = series.ProductionYear?.ToString() ?? "Unknown year";
-                        _logger.LogDebug("  + Series: '{Title}' ({Year})", series.Name, year);
-                    }
-                    break;
-            }
-            
-            _logger.LogInformation($"Found {allMovies.Count} movies and {allSeries.Count} series matching {matchTypeText} pattern '{titleMatchPair.TitleMatch}' for collection: {collectionName}");
-            
-            var mediaItems = DedupeMediaItems(allMovies.Cast<BaseItem>().Concat(allSeries.Cast<BaseItem>()).ToList());
+            var mediaItems = GetMatchingItemsForTitleMatchPair(titleMatchPair);
 
             await RemoveUnwantedMediaItems(collection, mediaItems);
-            await AddWantedMediaItems(collection, mediaItems);
-            await SortCollectionBy(collection, SortOrder.Descending);
+            await AddWantedMediaItems(collection, mediaItems, titleMatchPair.SortBy, titleMatchPair.SortOrder);
+            await SortCollectionBy(collection, titleMatchPair.SortBy, titleMatchPair.SortOrder);
             
             // Re-fetch the collection to get its updated children
             var updatedCollection = _libraryManager.GetItemById(collection.Id) as BoxSet;
@@ -1551,7 +1774,7 @@ namespace Jellyfin.Plugin.AutoCollections
         /// back and filtering in memory is what made large libraries with many actor/director
         /// collections take hours: that full scan ran once per person term, per collection.
         /// </remarks>
-        private List<Person> FindPersonsByName(string nameToMatch, bool caseSensitive)
+        private List<Person> FindPersonsByName(string nameToMatch, bool caseSensitive, bool exactMatch = false)
         {
             StringComparison comparison = caseSensitive
                 ? StringComparison.Ordinal
@@ -1565,7 +1788,9 @@ namespace Jellyfin.Plugin.AutoCollections
             }).OfType<Person>()
                 // NameContains is case-insensitive in the query, so a case-sensitive
                 // search still has to be narrowed down here.
-                .Where(p => p.Name != null && p.Name.Contains(nameToMatch, comparison))
+                .Where(p => p.Name != null && (exactMatch
+                    ? p.Name.Equals(nameToMatch, comparison)
+                    : p.Name.Contains(nameToMatch, comparison)))
                 .ToList();
         }
 
@@ -1573,9 +1798,9 @@ namespace Jellyfin.Plugin.AutoCollections
         // that match the given string (partial or exact matching)
         // This method uses Jellyfin's PersonTypes query parameter to ensure only
         // movies where the person has the specified role are returned
-        private IEnumerable<Movie> GetMoviesWithPerson(string personNameToMatch, string personType, bool caseSensitive)
+        private IEnumerable<Movie> GetMoviesWithPerson(string personNameToMatch, string personType, bool caseSensitive, bool exactMatch = false)
         {
-            var persons = FindPersonsByName(personNameToMatch, caseSensitive);
+            var persons = FindPersonsByName(personNameToMatch, caseSensitive, exactMatch);
 
             _logger.LogDebug("Found {Count} person(s) matching '{NameToMatch}' for {PersonType} search", 
                 persons.Count, personNameToMatch, personType);
@@ -1619,9 +1844,9 @@ namespace Jellyfin.Plugin.AutoCollections
         // that match the given string (partial or exact matching)
         // This method uses Jellyfin's PersonTypes query parameter to ensure only
         // series where the person has the specified role are returned
-        private IEnumerable<Series> GetSeriesWithPerson(string personNameToMatch, string personType, bool caseSensitive)
+        private IEnumerable<Series> GetSeriesWithPerson(string personNameToMatch, string personType, bool caseSensitive, bool exactMatch = false)
         {
-            var persons = FindPersonsByName(personNameToMatch, caseSensitive);
+            var persons = FindPersonsByName(personNameToMatch, caseSensitive, exactMatch);
 
             _logger.LogDebug("Found {Count} person(s) matching '{NameToMatch}' for {PersonType} search", 
                 persons.Count, personNameToMatch, personType);
@@ -2001,7 +2226,74 @@ namespace Jellyfin.Plugin.AutoCollections
         // ================================================================
         // This section contains methods for processing expression-based
         // collections using complex criteria and boolean logic.
-          // Process expression collections
+          /// <summary>
+        /// Resolves the items an advanced collection should contain, without touching the collection.
+        /// </summary>
+        /// <remarks>
+        /// Assumes the expression has already been parsed. Shared by the sync and by the preview
+        /// endpoint so both evaluate identically.
+        /// </remarks>
+        private List<BaseItem> GetMatchingItemsForExpressionCollection(Configuration.ExpressionCollection expressionCollection)
+        {
+            if (expressionCollection.ParsedExpression == null)
+            {
+                return new List<BaseItem>();
+            }
+
+            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Movie },
+                IsVirtualItem = false,
+                Recursive = true
+            }).OfType<Movie>().ToList();
+
+            var allSeries = _libraryManager.GetItemList(new InternalItemsQuery
+            {
+                IncludeItemTypes = new[] { BaseItemKind.Series },
+                IsVirtualItem = false,
+                Recursive = true
+            }).OfType<Series>().ToList();
+
+            _logger.LogInformation("Found {MovieCount} movies and {SeriesCount} series to evaluate",
+                allMovies.Count, allSeries.Count);
+
+            // Normally the cache is opened once for the whole run; only take ownership
+            // of it here when this collection is being evaluated on its own.
+            var ownsPersonCache = _personToMoviesCache == null;
+            if (ownsPersonCache)
+            {
+                InitializePersonCache();
+            }
+
+            try
+            {
+                var matchingMovies = allMovies
+                    .Where(movie => movie != null)
+                    .Where(movie => expressionCollection.ParsedExpression.Evaluate(
+                        (criteriaType, value) => EvaluateMovieCriteria(movie, criteriaType, value, expressionCollection.CaseSensitive)))
+                    .ToList();
+
+                var matchingSeries = allSeries
+                    .Where(series => series != null)
+                    .Where(series => expressionCollection.ParsedExpression.Evaluate(
+                        (criteriaType, value) => EvaluateSeriesCriteria(series, criteriaType, value, expressionCollection.CaseSensitive)))
+                    .ToList();
+
+                _logger.LogInformation("Expression matched {MovieCount} movies and {SeriesCount} series",
+                    matchingMovies.Count, matchingSeries.Count);
+
+                return DedupeMediaItems(matchingMovies.Cast<BaseItem>().Concat(matchingSeries.Cast<BaseItem>()).ToList());
+            }
+            finally
+            {
+                if (ownsPersonCache)
+                {
+                    ClearPersonCache();
+                }
+            }
+        }
+
+        // Process expression collections
         private async Task ExecuteAutoCollectionsForExpressionCollection(Configuration.ExpressionCollection expressionCollection)
         {
             _logger.LogInformation("Processing expression collection: {CollectionName}", expressionCollection.CollectionName);
@@ -2017,106 +2309,14 @@ namespace Jellyfin.Plugin.AutoCollections
             
             // Get or create the collection
             var collectionName = expressionCollection.CollectionName;
-            var (collection, isNewCollection) = await GetOrCreateCollectionAsync(collectionName);
+            var (collection, isNewCollection) = await GetOrCreateCollectionAsync(collectionName, expressionCollection.SortBy, expressionCollection.SortOrder);
             
-            // Get all movies and series from the library
-            var allMovies = _libraryManager.GetItemList(new InternalItemsQuery
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Movie },
-                IsVirtualItem = false,
-                Recursive = true
-            }).OfType<Movie>().ToList();
-            
-            var allSeries = _libraryManager.GetItemList(new InternalItemsQuery
-            {
-                IncludeItemTypes = new[] { BaseItemKind.Series },
-                IsVirtualItem = false,
-                Recursive = true
-            }).OfType<Series>().ToList();
-            
-            _logger.LogInformation("Found {MovieCount} movies and {SeriesCount} series to evaluate", 
-                allMovies.Count, allSeries.Count);
-            
-            _logger.LogDebug("Expression collection '{CollectionName}' - Expression: {Expression}", 
-                collectionName, expressionCollection.Expression);
-            
-            // Filter movies and series based on the expression
-            var matchingMovies = new List<Movie>();
-            var matchingSeries = new List<Series>();
-            
-            if (expressionCollection.ParsedExpression != null)
-            {
-                // Normally the cache is opened once for the whole run; only take ownership
-                // of it here when this collection is being processed on its own.
-                var ownsPersonCache = _personToMoviesCache == null;
-                if (ownsPersonCache)
-                {
-                    InitializePersonCache();
-                }
-
-                try
-                {
-                    _logger.LogDebug("Evaluating movies against expression...");
-                    
-                    matchingMovies = allMovies
-                        .Where(movie => movie != null)
-                        .Where(movie => 
-                        {
-                            var matches = expressionCollection.ParsedExpression.Evaluate(
-                                (criteriaType, value) => EvaluateMovieCriteria(movie, criteriaType, value, expressionCollection.CaseSensitive)
-                            );
-                            
-                            if (matches)
-                            {
-                                var year = movie.ProductionYear?.ToString() ?? "Unknown year";
-                                _logger.LogDebug("  ✓ Movie matched: '{Title}' ({Year}) (ID: {Id})", 
-                                    movie.Name, year, movie.Id);
-                            }
-                            
-                            return matches;
-                        })
-                        .ToList();
-                    
-                    _logger.LogDebug("Evaluating series against expression...");
-                        
-                    matchingSeries = allSeries
-                        .Where(series => series != null)
-                        .Where(series => 
-                        {
-                            var matches = expressionCollection.ParsedExpression.Evaluate(
-                                (criteriaType, value) => EvaluateSeriesCriteria(series, criteriaType, value, expressionCollection.CaseSensitive)
-                            );
-                            
-                            if (matches)
-                            {
-                                var year = series.ProductionYear?.ToString() ?? "Unknown year";
-                                _logger.LogDebug("  ✓ Series matched: '{Title}' ({Year}) (ID: {Id})", 
-                                    series.Name, year, series.Id);
-                            }
-                            
-                            return matches;
-                        })
-                        .ToList();
-                }
-                finally
-                {
-                    if (ownsPersonCache)
-                    {
-                        ClearPersonCache();
-                    }
-                }
-            }
-            
-            _logger.LogInformation("Expression matched {MovieCount} movies and {SeriesCount} series", 
-                matchingMovies.Count, matchingSeries.Count);
-                
-            // Combine movies and series
-            var allMatchingItems = DedupeMediaItems(matchingMovies.Cast<BaseItem>().Concat(matchingSeries.Cast<BaseItem>()).ToList());         
+            var allMatchingItems = GetMatchingItemsForExpressionCollection(expressionCollection);
 
             // Update the collection (add new items, remove items that no longer match)
             await RemoveUnwantedMediaItems(collection, allMatchingItems);
-            await AddWantedMediaItems(collection, allMatchingItems);
-            await SortCollectionBy(collection, SortOrder.Descending);
+            await AddWantedMediaItems(collection, allMatchingItems, expressionCollection.SortBy, expressionCollection.SortOrder);
+            await SortCollectionBy(collection, expressionCollection.SortBy, expressionCollection.SortOrder);
 
             // Re-fetch the collection to get its updated children
             var updatedCollection = _libraryManager.GetItemById(collection.Id) as BoxSet;

--- a/Jellyfin.Plugin.AutoCollections/Configuration/CollectionPreview.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/CollectionPreview.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.AutoCollections.Configuration
+{
+    /// <summary>
+    /// One item in a preview result.
+    /// </summary>
+    public class PreviewItem
+    {
+        public string Name { get; set; } = string.Empty;
+        public int? Year { get; set; }
+        public string Type { get; set; } = "Item";
+    }
+
+    /// <summary>
+    /// What a sync would do to one collection, without doing it.
+    /// </summary>
+    /// <remarks>
+    /// Reported as a difference against the collection's current contents rather than a plain
+    /// list of matches: a sync also removes items that stopped matching, and that is the part
+    /// worth seeing before it happens.
+    /// </remarks>
+    public class CollectionPreview
+    {
+        public string CollectionName { get; set; } = string.Empty;
+
+        /// <summary>False when the collection would be created by this sync.</summary>
+        public bool CollectionExists { get; set; }
+
+        /// <summary>How many items the collection would hold afterwards.</summary>
+        public int MatchedCount { get; set; }
+
+        /// <summary>How many items it holds right now.</summary>
+        public int CurrentCount { get; set; }
+
+        /// <summary>Items already in the collection that would stay.</summary>
+        public int UnchangedCount { get; set; }
+
+        public List<PreviewItem> Added { get; set; } = new();
+        public List<PreviewItem> Removed { get; set; } = new();
+
+        public int AddedCount { get; set; }
+        public int RemovedCount { get; set; }
+
+        /// <summary>Set when the lists were capped, so the UI can say "and N more".</summary>
+        public bool AddedTruncated { get; set; }
+        public bool RemovedTruncated { get; set; }
+
+        /// <summary>Things that look like mistakes but are not errors.</summary>
+        public List<string> Warnings { get; set; } = new();
+
+        /// <summary>Expression parse failures.</summary>
+        public List<string> Errors { get; set; } = new();
+    }
+}

--- a/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/ExpressionCollection.cs
@@ -186,6 +186,8 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         public string CollectionName { get; set; }
         public string Expression { get; set; }
         public bool CaseSensitive { get; set; }
+        public CollectionSortBy SortBy { get; set; }
+        public CollectionSortOrder SortOrder { get; set; }
 
         // Make ParsedExpression and ParseErrors non-serializable
         [System.Xml.Serialization.XmlIgnore]
@@ -202,6 +204,8 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
             CollectionName = "Auto Collection";
             Expression = string.Empty;
             CaseSensitive = false;
+            SortBy = CollectionSortBy.ReleaseYear;
+            SortOrder = CollectionSortOrder.Descending;
             ParseErrors = new List<string>();
         }
 
@@ -210,6 +214,8 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
             CollectionName = collectionName;
             Expression = expression;
             CaseSensitive = caseSensitive;
+            SortBy = CollectionSortBy.ReleaseYear;
+            SortOrder = CollectionSortOrder.Descending;
             ParseErrors = new List<string>();
 
             // Parse expression when created

--- a/Jellyfin.Plugin.AutoCollections/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/PluginConfiguration.cs
@@ -69,6 +69,23 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         Writer = 6   // Match by writer
     }
     
+    // How the items inside a collection are ordered
+    public enum CollectionSortBy
+    {
+        ReleaseYear = 0,     // Default - production year, then premiere date
+        DateAdded = 1,       // When the item was added to the library
+        Name = 2,            // Sort name
+        CommunityRating = 3, // Community rating
+        Runtime = 4,         // Duration
+        Random = 5           // Shuffled by Jellyfin on every view
+    }
+
+    public enum CollectionSortOrder
+    {
+        Descending = 0, // Default - newest first, matching the behaviour before this was configurable
+        Ascending = 1
+    }
+
     // Media types for filtering collections
     public enum MediaTypeFilter
     {
@@ -85,6 +102,9 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
         public bool CaseSensitive { get; set; }
         public MatchType MatchType { get; set; }
         public MediaTypeFilter MediaType { get; set; }
+        public bool ExactMatch { get; set; }
+        public CollectionSortBy SortBy { get; set; }
+        public CollectionSortOrder SortOrder { get; set; }
 
         // Add parameterless constructor for XML serialization
         public TitleMatchPair()
@@ -94,6 +114,9 @@ namespace Jellyfin.Plugin.AutoCollections.Configuration
             CaseSensitive = false; // Default to case insensitive
             MatchType = MatchType.Title; // Default to title matching for backward compatibility
             MediaType = MediaTypeFilter.All; // Default to include all media types
+            ExactMatch = false; // Default to substring matching for backward compatibility
+            SortBy = CollectionSortBy.ReleaseYear;
+            SortOrder = CollectionSortOrder.Descending;
         }
 
         public TitleMatchPair(string titleMatch, string collectionName = null, bool caseSensitive = false, 

--- a/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.AutoCollections/Configuration/configurationpage.html
@@ -15,6 +15,37 @@
       .match-type-select {
         width: 100%;
       }
+      .preview-panel {
+        width: 100%;
+        margin-top: 8px;
+        padding: 10px 12px;
+        border-radius: 4px;
+        background-color: rgba(0,0,0,0.18);
+        font-size: 14px;
+        max-height: 320px;
+        overflow-y: auto;
+      }
+      .preview-summary { margin-bottom: 6px; }
+      .preview-item { padding: 1px 0 1px 12px; }
+      .preview-added { color: #4caf50; margin-left: 8px; }
+      .preview-removed { color: #e57373; margin-left: 8px; }
+      .preview-muted { opacity: 0.7; margin-left: 8px; }
+      .preview-more { opacity: 0.7; font-style: italic; }
+      .preview-warning {
+        margin: 6px 0;
+        padding: 6px 8px;
+        border-radius: 3px;
+        background-color: rgba(229,115,115,0.18);
+      }
+      .preview-panel summary { cursor: pointer; padding: 3px 0; }
+      .preview-table { width: 100%; border-collapse: collapse; }
+      .preview-table th, .preview-table td {
+        text-align: left;
+        padding: 4px 10px 4px 0;
+        border-bottom: 1px solid rgba(255,255,255,0.1);
+      }
+      .preview-table td.num { text-align: right; }
+
       .title-match-input {
         flex: 1;
         margin-right: 10px;
@@ -192,6 +223,17 @@
               is="emby-button"
               type="button"
               class="raised block"
+              id="preview-all-button"
+            >
+              <span>Preview All (no changes are made)</span>
+            </button>
+            <div id="preview-all-panel" class="preview-panel" style="display:none"></div>
+
+            <br />
+            <button
+              is="emby-button"
+              type="button"
+              class="raised block"
               id="sync-Auto-collections"
               onclick="execute()"
             >
@@ -201,7 +243,184 @@
         </div>
       </div>      <script type="text/javascript" defer>
         // For expression-based collections
-        function createExpressionCollectionElement(expression = '', collectionName = '', caseSensitive = false) {
+        // ---- shared row controls -------------------------------------------------
+
+        // Plugin configuration comes back with enums as either their name or their number,
+        // so both have to be understood. Names must stay in enum order.
+        const MATCH_TYPE_NAMES = ['Title', 'Genre', 'Studio', 'Actor', 'Director', 'Tag', 'Writer'];
+        const MEDIA_TYPE_NAMES = ['All', 'Movies', 'Series'];
+        const SORT_BY_NAMES = ['ReleaseYear', 'DateAdded', 'Name', 'CommunityRating', 'Runtime', 'Random'];
+        const SORT_ORDER_NAMES = ['Descending', 'Ascending'];
+
+        function enumName(index, names) {
+          const i = parseInt(index, 10);
+          return names[i] !== undefined ? names[i] : names[0];
+        }
+
+        function enumIndex(value, names) {
+          if (typeof value === 'number') {
+            return value;
+          }
+          const found = names.indexOf(value);
+          return found === -1 ? 0 : found;
+        }
+
+        const SORT_BY_OPTIONS = [
+          { value: '0', text: 'Release year' },
+          { value: '1', text: 'Date added' },
+          { value: '2', text: 'Name' },
+          { value: '3', text: 'Community rating' },
+          { value: '4', text: 'Runtime' },
+          { value: '5', text: 'Random' }
+        ];
+
+        const SORT_ORDER_OPTIONS = [
+          { value: '0', text: 'Desc' },
+          { value: '1', text: 'Asc' }
+        ];
+
+        function buildSelect(className, options, selected, width) {
+          const wrapper = document.createElement('div');
+          wrapper.style.marginRight = '10px';
+          wrapper.style.minWidth = width;
+          wrapper.style.flex = '0 0 ' + width;
+
+          const select = document.createElement('select');
+          select.is = 'emby-select';
+          select.className = className;
+          options.forEach(function (opt) {
+            const option = document.createElement('option');
+            option.value = opt.value;
+            option.text = opt.text;
+            select.appendChild(option);
+          });
+          select.value = String(selected);
+          wrapper.appendChild(select);
+          return wrapper;
+        }
+
+        function buildSortControls(sortBy, sortOrder) {
+          return [
+            buildSelect('sort-by-select', SORT_BY_OPTIONS, sortBy, '130px'),
+            buildSelect('sort-order-select', SORT_ORDER_OPTIONS, sortOrder, '70px')
+          ];
+        }
+
+        function buildCheckbox(className, labelText, checked) {
+          const wrap = document.createElement('div');
+          wrap.style.display = 'flex';
+          wrap.style.alignItems = 'center';
+          wrap.style.marginRight = '10px';
+
+          const box = document.createElement('input');
+          box.is = 'emby-checkbox';
+          box.type = 'checkbox';
+          box.className = className;
+          box.checked = checked;
+
+          const label = document.createElement('span');
+          label.textContent = labelText;
+          label.style.marginLeft = '5px';
+          label.style.fontSize = '14px';
+
+          wrap.appendChild(box);
+          wrap.appendChild(label);
+          return wrap;
+        }
+
+        // ---- preview -------------------------------------------------------------
+
+        function escapeHtml(text) {
+          const div = document.createElement('div');
+          div.textContent = text == null ? '' : String(text);
+          return div.innerHTML;
+        }
+
+        function itemLine(item) {
+          const year = item.Year ? ' (' + item.Year + ')' : '';
+          return '<div class="preview-item">' + escapeHtml(item.Name) + escapeHtml(year) + '</div>';
+        }
+
+        function itemGroup(title, items, total, truncated, open) {
+          if (total === 0) {
+            return '';
+          }
+          const shown = items.map(itemLine).join('');
+          const more = truncated || items.length < total
+            ? '<div class="preview-item preview-more">… ' + (total - items.length) + ' more</div>'
+            : '';
+          return '<details' + (open ? ' open' : '') + '>'
+            + '<summary>' + escapeHtml(title) + ' (' + total + ')</summary>'
+            + shown + more
+            + '</details>';
+        }
+
+        function renderPreview(result) {
+          if (result.Errors && result.Errors.length) {
+            return '<div class="preview-warning">Expression could not be parsed: '
+              + escapeHtml(result.Errors.join('; ')) + '</div>';
+          }
+
+          const summary = result.CollectionExists
+            ? '<b>' + result.MatchedCount + ' items</b>'
+                + '<span class="preview-added"> +' + result.AddedCount + ' added</span>'
+                + '<span class="preview-removed"> −' + result.RemovedCount + ' removed</span>'
+                + '<span class="preview-muted"> ' + result.UnchangedCount + ' unchanged</span>'
+            : '<b>' + result.MatchedCount + ' items</b>'
+                + '<span class="preview-muted"> — this collection would be created</span>';
+
+          const warnings = (result.Warnings || [])
+            .map(function (w) { return '<div class="preview-warning">⚠ ' + escapeHtml(w) + '</div>'; })
+            .join('');
+
+          // Removals are what people need to see before syncing, so that group starts open.
+          return '<div class="preview-summary">' + summary + '</div>'
+            + warnings
+            + itemGroup('Removed', result.Removed || [], result.RemovedCount, result.RemovedTruncated, true)
+            + itemGroup('Added', result.Added || [], result.AddedCount, result.AddedTruncated, false)
+            + (result.UnchangedCount > 0
+                ? '<div class="preview-muted preview-item">' + result.UnchangedCount + ' unchanged</div>'
+                : '');
+        }
+
+        function attachPreview(container, buildPayload) {
+          const panel = document.createElement('div');
+          panel.className = 'preview-panel';
+          panel.style.display = 'none';
+
+          const button = document.createElement('button');
+          button.is = 'emby-button';
+          button.type = 'button';
+          button.className = 'raised preview-button';
+          button.innerHTML = '<span>Preview</span>';
+          button.style.flex = '0 0 auto';
+          button.style.marginRight = '10px';
+
+          button.addEventListener('click', function () {
+            const payload = buildPayload();
+            if (!payload) {
+              return;
+            }
+            panel.style.display = 'block';
+            panel.innerHTML = '<div class="preview-muted preview-item">Checking…</div>';
+
+            ApiClient.ajax({
+              type: 'POST',
+              url: ApiClient.getUrl('/AutoCollections/Preview'),
+              data: JSON.stringify(payload),
+              contentType: 'application/json',
+              dataType: 'json'
+            }).then(function (result) {
+              panel.innerHTML = renderPreview(result);
+            }).catch(function () {
+              panel.innerHTML = '<div class="preview-warning">Preview failed. Check the server log.</div>';
+            });
+          });
+
+          return { button: button, panel: panel };
+        }
+
+        function createExpressionCollectionElement(expression = '', collectionName = '', caseSensitive = false, sortBy = 0, sortOrder = 0) {
           const container = document.createElement('div');
           container.className = 'expression-container';
           container.style.display = 'flex';
@@ -284,16 +503,37 @@
             container.remove();
           };
           
+          const sortControls = buildSortControls(sortBy, sortOrder);
+
+          const preview = attachPreview(container, function () {
+            const expressionValue = container.querySelector('.expression-input').value.trim();
+            if (!expressionValue) {
+              return null;
+            }
+            return {
+              Advanced: {
+                CollectionName: container.querySelector('.collection-name-input').value.trim() || 'Expression Collection',
+                Expression: expressionValue,
+                CaseSensitive: container.querySelector('.case-sensitive-checkbox').checked,
+                SortBy: parseInt(container.querySelector('.sort-by-select').value, 10),
+                SortOrder: parseInt(container.querySelector('.sort-order-select').value, 10)
+              }
+            };
+          });
+
           // Add all components
           container.appendChild(collectionNameContainer);
           container.appendChild(expressionContainer);
           container.appendChild(caseCheckContainer);
+          sortControls.forEach(function (c) { container.appendChild(c); });
+          container.appendChild(preview.button);
           container.appendChild(removeButton);
+          container.appendChild(preview.panel);
           
           return container;
         }
         
-        function createTitleMatchPairElement(titleMatch = '', collectionName = '', caseSensitive = false, matchType = 0, mediaType = 0) {
+        function createTitleMatchPairElement(titleMatch = '', collectionName = '', caseSensitive = false, matchType = 0, mediaType = 0, exactMatch = false, sortBy = 0, sortOrder = 0) {
           const container = document.createElement('div');
           container.className = 'title-match-container';
           container.style.display = 'flex';
@@ -486,13 +726,39 @@
             container.remove();
           };
           
+          const exactContainer = buildCheckbox('exact-match-checkbox', 'Exact', exactMatch);
+          const sortControls = buildSortControls(sortBy, sortOrder);
+
+          const preview = attachPreview(container, function () {
+            const matchValue = container.querySelector('.title-match-input').value.trim();
+            if (!matchValue) {
+              return null;
+            }
+            return {
+              Simple: {
+                TitleMatch: matchValue,
+                CollectionName: container.querySelector('.collection-name-input').value.trim() || 'Auto Collection',
+                CaseSensitive: container.querySelector('.case-sensitive-checkbox').checked,
+                MatchType: parseInt(container.querySelector('.match-type-select').value, 10),
+                MediaType: parseInt(container.querySelector('.media-type-select').value, 10),
+                ExactMatch: container.querySelector('.exact-match-checkbox').checked,
+                SortBy: parseInt(container.querySelector('.sort-by-select').value, 10),
+                SortOrder: parseInt(container.querySelector('.sort-order-select').value, 10)
+              }
+            };
+          });
+
           // Add all components to container in order
           container.appendChild(matchTypeContainer);
           container.appendChild(mediaTypeContainer); // Add media type dropdown
           container.appendChild(titleMatchContainer);
           container.appendChild(collectionNameContainer);
           container.appendChild(caseCheckContainer);
+          container.appendChild(exactContainer);
+          sortControls.forEach(function (c) { container.appendChild(c); });
+          container.appendChild(preview.button);
           container.appendChild(removeButton);
+          container.appendChild(preview.panel);
           
           return container;
         }
@@ -511,60 +777,20 @@
               // Check if we have the TitleMatchPairs property
               if (config.TitleMatchPairs && config.TitleMatchPairs.length > 0) {
                 config.TitleMatchPairs.forEach(pair => {                  
-                  // Convert MatchType enum string to numeric value for the dropdown
-                  let matchTypeValue = 0; // Default to Title
-                  if (pair.MatchType !== undefined) {
-                    switch (pair.MatchType) {
-                      case "Title":
-                        matchTypeValue = 0;
-                        break;
-                      case "Genre":
-                        matchTypeValue = 1;
-                        break;
-                      case "Studio":
-                        matchTypeValue = 2;
-                        break;
-                      case "Actor":
-                        matchTypeValue = 3;
-                        break;
-                      case "Director":
-                        matchTypeValue = 4;
-                        break;
-                      // Fallback for numeric values (backward compatibility)
-                      default:
-                        if (typeof pair.MatchType === 'number') {
-                          matchTypeValue = pair.MatchType;
-                        }
-                    }
-                  }
+                  const matchTypeValue = enumIndex(pair.MatchType, MATCH_TYPE_NAMES);
+                  const mediaTypeValue = enumIndex(pair.MediaType, MEDIA_TYPE_NAMES);
+                  const sortByValue = enumIndex(pair.SortBy, SORT_BY_NAMES);
+                  const sortOrderValue = enumIndex(pair.SortOrder, SORT_ORDER_NAMES);
 
-                  // Convert MediaType enum to numeric value for the dropdown
-                  let mediaTypeValue = 0; // Default to All
-                  if (pair.MediaType !== undefined) {
-                    switch (pair.MediaType) {
-                      case "All":
-                        mediaTypeValue = 0;
-                        break;
-                      case "Movies":
-                        mediaTypeValue = 1;
-                        break;
-                      case "Series":
-                        mediaTypeValue = 2;
-                        break;
-                      // Fallback for numeric values (backward compatibility)
-                      default:
-                        if (typeof pair.MediaType === 'number') {
-                          mediaTypeValue = pair.MediaType;
-                        }
-                    }
-                  }
-                  
                   const element = createTitleMatchPairElement(
-                    pair.TitleMatch, 
-                    pair.CollectionName, 
-                    pair.CaseSensitive, 
+                    pair.TitleMatch || '',
+                    pair.CollectionName || '',
+                    pair.CaseSensitive || false,
                     matchTypeValue,
-                    mediaTypeValue
+                    mediaTypeValue,
+                    pair.ExactMatch === true,
+                    sortByValue,
+                    sortOrderValue
                   );
                   titleMatchPairsContainer.appendChild(element);
                 });
@@ -587,7 +813,9 @@
                   const element = createExpressionCollectionElement(
                     collection.Expression,
                     collection.CollectionName,
-                    collection.CaseSensitive
+                    collection.CaseSensitive,
+                    enumIndex(collection.SortBy, SORT_BY_NAMES),
+                    enumIndex(collection.SortOrder, SORT_ORDER_NAMES)
                   );
                   expressionCollectionsContainer.appendChild(element);
                 });
@@ -606,7 +834,57 @@
               const expressionElement = createExpressionCollectionElement();
               document.querySelector("#expression-collections").appendChild(expressionElement);
             });
-        }        function saveConfig() {
+        }
+
+        // Builds the configuration object from what is currently on the page.
+        // Shared by Save and by Preview All, so a preview reflects unsaved edits.
+        function buildConfigPayload() {
+          const titleMatchPairs = [];
+          document.querySelectorAll('.title-match-container').forEach(container => {
+            const titleMatchInput = container.querySelector('.title-match-input');
+            if (!titleMatchInput.value.trim()) {
+              return;
+            }
+            const collectionName = container.querySelector('.collection-name-input').value.trim();
+            titleMatchPairs.push({
+              TitleMatch: titleMatchInput.value.trim(),
+              CollectionName: collectionName || null, // Use null if collection name is empty
+              CaseSensitive: container.querySelector('.case-sensitive-checkbox').checked,
+              MatchType: enumName(container.querySelector('.match-type-select').value, MATCH_TYPE_NAMES),
+              MediaType: enumName(container.querySelector('.media-type-select').value, MEDIA_TYPE_NAMES),
+              ExactMatch: container.querySelector('.exact-match-checkbox').checked,
+              SortBy: enumName(container.querySelector('.sort-by-select').value, SORT_BY_NAMES),
+              SortOrder: enumName(container.querySelector('.sort-order-select').value, SORT_ORDER_NAMES)
+            });
+          });
+
+          const expressionCollections = [];
+          document.querySelectorAll('.expression-container').forEach(container => {
+            const expressionInput = container.querySelector('.expression-input');
+            if (!expressionInput.value.trim()) {
+              return;
+            }
+            expressionCollections.push({
+              Expression: expressionInput.value.trim(),
+              CollectionName: container.querySelector('.collection-name-input').value.trim() || "Expression Collection",
+              CaseSensitive: container.querySelector('.case-sensitive-checkbox').checked,
+              SortBy: enumName(container.querySelector('.sort-by-select').value, SORT_BY_NAMES),
+              SortOrder: enumName(container.querySelector('.sort-order-select').value, SORT_ORDER_NAMES)
+            });
+          });
+
+          return {
+            TitleMatchPairs: titleMatchPairs,
+            ExpressionCollections: expressionCollections,
+            IsInitialized: true, // Mark as initialized to prevent defaults from being re-added
+            DeleteOrphanedCollections: document.querySelector("#delete-orphaned-collections").checked,
+            // Keep these empty for backward compatibility
+            TagTitlePairs: [],
+            Tags: []
+          };
+        }
+
+        function saveConfig() {
           // Validate expressions before saving
           let allExpressionContainers = document.querySelectorAll('.expression-container');
           let hasErrors = false;
@@ -626,97 +904,7 @@
             return; // Don't save if there are validation errors
           }
           
-          // Process simple collections
-          const titleMatchContainers = document.querySelectorAll('.title-match-container');
-          const titleMatchPairs = [];
-            
-          titleMatchContainers.forEach(container => {
-            // Handle our new nested structure
-            const titleMatchInput = container.querySelector('.title-match-input');
-            const collectionNameInput = container.querySelector('.collection-name-input');
-            const caseSensitiveCheckbox = container.querySelector('.case-sensitive-checkbox');
-            const matchTypeSelect = container.querySelector('.match-type-select');
-            const mediaTypeSelect = container.querySelector('.media-type-select');
-              if (titleMatchInput.value.trim()) {
-              const titleMatch = titleMatchInput.value.trim();
-              const collectionName = collectionNameInput.value.trim();
-              const caseSensitive = caseSensitiveCheckbox.checked;
-              // Convert numeric value to enum string representation
-              const matchTypeValue = parseInt(matchTypeSelect.value, 10);
-              let matchTypeString;
-              switch (matchTypeValue) {
-                case 0:
-                  matchTypeString = "Title";
-                  break;
-                case 1:
-                  matchTypeString = "Genre";
-                  break;
-                case 2:
-                  matchTypeString = "Studio";
-                  break;
-                case 3:
-                  matchTypeString = "Actor";
-                  break;
-                case 4:
-                  matchTypeString = "Director";
-                  break;
-                default:
-                  matchTypeString = "Title";
-              }
-              
-
-              // Convert numeric value to enum string representation for media type
-              const mediaTypeValue = parseInt(mediaTypeSelect.value, 10);
-              let mediaTypeString;
-              switch (mediaTypeValue) {
-                case 0:
-                  mediaTypeString = "All";
-                  break;
-                case 1:
-                  mediaTypeString = "Movies";
-                  break;
-                case 2:
-                  mediaTypeString = "Series";
-                  break;
-                default:
-                  mediaTypeString = "All";
-              }
-              
-              titleMatchPairs.push({
-                TitleMatch: titleMatch,
-                CollectionName: collectionName || null, // Use null if collection name is empty
-                CaseSensitive: caseSensitive,
-                MatchType: matchTypeString,
-                MediaType: mediaTypeString
-              });
-            }
-          });
-            // Process expression collections
-          const expressionCollections = [];
-          
-          allExpressionContainers.forEach(container => {
-            const expressionInput = container.querySelector('.expression-input');
-            const collectionNameInput = container.querySelector('.collection-name-input');
-            const caseSensitiveCheckbox = container.querySelector('.case-sensitive-checkbox');
-            
-            if (expressionInput.value.trim()) {
-              expressionCollections.push({
-                Expression: expressionInput.value.trim(),
-                CollectionName: collectionNameInput.value.trim() || "Expression Collection",
-                CaseSensitive: caseSensitiveCheckbox.checked
-              });
-            }
-          });
-          
-          const config = {
-            TitleMatchPairs: titleMatchPairs,
-            ExpressionCollections: expressionCollections,
-            IsInitialized: true, // Mark as initialized to prevent defaults from being re-added
-            DeleteOrphanedCollections: document.querySelector("#delete-orphaned-collections").checked,
-            // Keep these empty for backward compatibility
-            TagTitlePairs: [],
-            Tags: []
-          };
+          const config = buildConfigPayload();
           
           window.ApiClient.updatePluginConfiguration(
             "06ebf4a9-1326-4327-968d-8da00e1ea2eb",
@@ -743,7 +931,61 @@
                 message: "Unexpected error occurred!"
               });
             });
-        }        // Initialize the page
+        }        function collectConfigFromPage() {
+          return buildConfigPayload();
+        }
+
+        function renderPreviewAll(results) {
+          if (!results.length) {
+            return '<div class="preview-muted preview-item">No collections are configured.</div>';
+          }
+
+          const rows = results.map(function (r) {
+            const needsAttention = (r.Warnings && r.Warnings.length) || (r.Errors && r.Errors.length);
+            const status = needsAttention ? ' ⚠' : '';
+            const counts = (r.Errors && r.Errors.length)
+              ? '<td colspan="3">' + escapeHtml(r.Errors.join('; ')) + '</td>'
+              : '<td class="num">' + r.MatchedCount + '</td>'
+                + '<td class="num preview-added">+' + r.AddedCount + '</td>'
+                + '<td class="num preview-removed">−' + r.RemovedCount + '</td>';
+            return '<tr><td>' + escapeHtml(r.CollectionName) + status + '</td>' + counts + '</tr>';
+          }).join('');
+
+          const flagged = results.filter(function (r) {
+            return (r.Warnings && r.Warnings.length) || (r.Errors && r.Errors.length);
+          });
+
+          const detail = flagged.map(function (r) {
+            const notes = (r.Errors || []).concat(r.Warnings || [])
+              .map(function (w) { return '<div class="preview-warning">⚠ ' + escapeHtml(r.CollectionName) + ': ' + escapeHtml(w) + '</div>'; })
+              .join('');
+            return notes;
+          }).join('');
+
+          return '<table class="preview-table">'
+            + '<tr><th>Collection</th><th class="num">Items</th><th class="num">Added</th><th class="num">Removed</th></tr>'
+            + rows + '</table>' + detail;
+        }
+
+        document.querySelector('#preview-all-button').addEventListener('click', function () {
+          const panel = document.querySelector('#preview-all-panel');
+          panel.style.display = 'block';
+          panel.innerHTML = '<div class="preview-muted preview-item">Checking every collection…</div>';
+
+          ApiClient.ajax({
+            type: 'POST',
+            url: ApiClient.getUrl('/AutoCollections/PreviewAll'),
+            data: JSON.stringify(collectConfigFromPage()),
+            contentType: 'application/json',
+            dataType: 'json'
+          }).then(function (results) {
+            panel.innerHTML = renderPreviewAll(results);
+          }).catch(function () {
+            panel.innerHTML = '<div class="preview-warning">Preview failed. Check the server log.</div>';
+          });
+        });
+
+        // Initialize the page
         loadConfig();
         
         // Add event listeners

--- a/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
+++ b/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <AssemblyVersion>0.0.6.0</AssemblyVersion>
-    <FileVersion>0.0.6.0</FileVersion>
+    <AssemblyVersion>0.0.7.0</AssemblyVersion>
+    <FileVersion>0.0.7.0</FileVersion>
     <Authors />
     <Company />
     <RootNamespace>Jellyfin.Plugin.AutoCollections</RootNamespace>
@@ -18,9 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- ASP.NET Core comes from the Jellyfin server that loads the plugin. The old
+         Microsoft.AspNetCore.Mvc 2.2.0 package used to be referenced here instead; it
+         also dragged in an analyzer that crashes (AD0001) on modern Roslyn. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
     <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.11" />
   </ItemGroup>
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := 0.0.6.0
+export VERSION := 0.0.7.0
 export GITHUB_REPO := KeksBombe/jellyfin-plugin-auto-collections
 export FILE := auto-collections-${VERSION}.zip
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,46 @@ collection never needs editing by hand.
 - **Real-time Maintenance**: Collections stay current as library changes
 
 #### Collection Management
-- **Auto-Sorting**: Items sorted by production year and premiere date
+- **Sorting**: Choose the order of each collection - release year, date added, name, rating, runtime or random, ascending or descending
+- **Preview**: See exactly what a sync would add and remove before running it
 - **Deduplication**: Prevents duplicate entries in collections
 - **Image Assignment**: Automatically sets collection artwork from content, and never replaces artwork you set yourself
 - **Smart Naming**: Intelligent default collection names based on criteria
 - **Name Protection**: Collections are locked so metadata providers cannot rename them or swap their artwork
 - **Orphan Cleanup** (optional, off by default): Delete collections once they are removed from the configuration. Only collections created by this plugin are ever removed
+
+### Sorting
+
+Each collection has its own sort field and direction, set next to it in the plugin page.
+
+| Sort by | Notes |
+| --- | --- |
+| Release year | Default. Production year, then premiere date |
+| Date added | When the item was added to the library |
+| Name | Sort name |
+| Community rating | |
+| Runtime | |
+| Random | Reshuffled by Jellyfin each time the collection is opened |
+
+Ascending orders are handed to Jellyfin, which sorts the collection when it is viewed and keeps
+it correct as items change. Jellyfin only ever sorts a collection ascending, so descending orders
+are produced by controlling the order items are stored in instead. Both work; the ascending ones
+are simply cheaper and stay right without a sync.
+
+### Preview (dry run)
+
+Every collection has a **Preview** button, and there is a **Preview All** button above Sync.
+Nothing is written to the library by either.
+
+A preview reports the difference against what the collection holds today, not just a list of
+matches - a sync also removes items that stopped matching, and that is usually the part worth
+checking. It reads the values currently on the page, so a rule can be checked before it is saved.
+
+It flags the cases that normally mean a rule is not doing what was intended:
+
+- nothing matches, or everything currently in the collection would be removed
+- more than half the library matches
+- `AND` and `OR` are mixed without brackets, where `AND` binds first
 
 ### 📊 Configuration Management
 
@@ -216,9 +250,10 @@ collection never needs editing by hand.
 2. Choose match type: Title, Genre, Studio, Actor, Director, Writer, or Tag
 3. Set media type filter: All, Movies only, or Shows only
 4. Enter search string
-5. Configure case sensitivity
-6. Set custom collection name (optional)
-7. Click "Save" and "Sync Auto Collections"
+5. Configure case sensitivity, and tick **Exact** to require the whole value to match rather than any part of it
+6. Choose how the collection is ordered (see [Sorting](#sorting))
+7. Set custom collection name (optional)
+8. Click **Preview** to see what would happen, then "Save" and "Sync Auto Collections"
 
 ### Advanced Collections Setup
 
@@ -324,6 +359,8 @@ First-time users receive example collections:
 
 #### Collection Management
 - `POST /AutoCollections/AutoCollections` - Trigger collection sync
+- `POST /AutoCollections/Preview` - Preview one collection without changing anything
+- `POST /AutoCollections/PreviewAll` - Preview every collection in the posted configuration
 - `GET /AutoCollections/ExportConfiguration` - Export configuration as JSON
 - `POST /AutoCollections/ImportConfiguration` - Import configuration (overwrite)
 - `POST /AutoCollections/AddConfiguration` - Add configuration (merge)

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-auto-collections"
 guid: "06ebf4a9-1326-4327-968d-8da00e1ea2eb"
-version: "0.0.6.0" # Please increment with each pull request
+version: "0.0.7.0" # Please increment with each pull request
 jellyfin_version: "10.11.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Auto Collections"


### PR DESCRIPTION
Sorting and the dry run, plus exact title matching. Version bumped to 0.0.7.0.

Closes #25, #46, #9, #37.

### Sorting

Every collection gets its own sort field and direction, set next to it on the plugin page: release year, date added, name, community rating, runtime or random.

Worth knowing how this works, because it isn't obvious. Jellyfin sorts a collection by its `DisplayOrder` field, but `BoxSet.Sort` always passes `SortOrder.Ascending` — there's no way to ask it for descending. So ascending orders get handed to Jellyfin, which sorts on read and stays correct as the library changes, while descending is produced here by controlling the order items are stored in, with `DisplayOrder` left on "Default" (the value that makes Jellyfin return them untouched). Ascending collections now skip the remove-and-re-add pass completely, so they're cheaper to sync as well.

This also clears up something inconsistent. Before 0.0.5.0 `DisplayOrder` was only ever set in memory, so it stuck on collections where the image step happened to save the item afterwards and not on the rest — some collections ended up ordered by release date, others by insertion order, with nothing to explain it. Now it's whatever you picked.

### Preview

A Preview button on each collection, and Preview All above Sync. Neither writes anything.

The result is a difference against what the collection holds today rather than a list of what matches, because a sync also removes what stopped matching and that's the part worth seeing first:

```
34 items    +2 added   −41 removed   32 unchanged
⚠ 41 of the 73 items currently in this collection would be removed
```

Removed is expanded by default, added and unchanged are collapsed. Long lists cap at 200 with a count of the rest.

It reads the boxes as they are on the page, not the saved config, so you can check a rule before saving it — which matters, since saving is what lets the scheduled task act on it.

Warnings cover the shapes that usually mean the rule isn't doing what was intended: nothing matches, the collection would be emptied, more than half the library matches, or AND and OR are mixed without brackets. That last one is behind a good number of the "not working" issues.

Matching was pulled out of the two execute methods into shared functions, so the sync and the preview can't drift apart.

### Exact matching

Simple collections get an Exact checkbox — the whole value has to match rather than any part of it. Applies to titles, genres, studios and person names, so `ACTOR "Chris Evans"` no longer also picks up Chris Evanson.

### Two things found on the way

Tag and Writer were being lost when saving or loading a simple collection. Both conversions used a switch that fell through to Title for anything unlisted, and neither got updated when those match types were added — so picking Tag or Writer, saving, and reloading gave you Title back. Replaced with a lookup that can't drift from the enum.

Also dropped the `Microsoft.AspNetCore.Mvc` 2.2.0 package in favour of a framework reference. ASP.NET Core comes from the server that loads the plugin, and that 2018 package drags in an analyzer that crashes on current Roslyn.
