### PR TITLE
Require auth on API endpoints; fix person lookup on Jellyfin 10.11

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
+++ b/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
@@ -35,6 +35,7 @@ namespace Jellyfin.Plugin.AutoCollections.Api
     /// The Auto Collections api controller.
     /// </summary>
     [ApiController]
+    [Authorize(Policy = "RequiresElevation")]
     [Route("AutoCollections")]
     [Produces(MediaTypeNames.Application.Json)]
 

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -16,6 +17,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Providers;
 using Jellyfin.Plugin.AutoCollections.Configuration;
@@ -1776,21 +1778,22 @@ namespace Jellyfin.Plugin.AutoCollections
         /// </remarks>
         private List<Person> FindPersonsByName(string nameToMatch, bool caseSensitive, bool exactMatch = false)
         {
-            StringComparison comparison = caseSensitive
-                ? StringComparison.Ordinal
-                : StringComparison.OrdinalIgnoreCase;
+            var compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+            var comparison = caseSensitive
+                ? CompareOptions.IgnoreNonSpace
+                : CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace;
 
             return _libraryManager.GetItemList(new InternalItemsQuery
             {
                 IncludeItemTypes = new[] { BaseItemKind.Person },
                 Recursive = true,
-                NameContains = nameToMatch
+                // Jellyfin 10.11 compares NameContains directly against CleanName.
+                NameContains = nameToMatch.RemoveDiacritics().ToLowerInvariant()
             }).OfType<Person>()
-                // NameContains is case-insensitive in the query, so a case-sensitive
-                // search still has to be narrowed down here.
+                // Preserve exact/case-sensitive matching without rejecting diacritic variants.
                 .Where(p => p.Name != null && (exactMatch
-                    ? p.Name.Equals(nameToMatch, comparison)
-                    : p.Name.Contains(nameToMatch, comparison)))
+                    ? compareInfo.Compare(p.Name, nameToMatch, comparison) == 0
+                    : compareInfo.IndexOf(p.Name, nameToMatch, comparison) >= 0))
                 .ToList();
         }
 


### PR DESCRIPTION
This PR contains two separate commits:

1. **Require administrator authentication for all six AutoCollections API endpoints.** Add `[Authorize(Policy = "RequiresElevation")]` to the controller, covering sync, previews, configuration export, import, and merge. Without an authorization attribute these endpoints were anonymously accessible, including persistent configuration writes. The reported reproduction on Jellyfin 10.11.11 returned **200** for `GET /AutoCollections/ExportConfiguration` without a token, while the core `GET /Plugins` returned **401**; unauthenticated `POST /AutoCollections/Preview` also returned movie listings. These live observations were supplied with the bug report and were not independently repeated here. The configuration page already uses `ApiClient.ajax`/`ApiClient.fetch`, or explicit `X-MediaBrowser-Token` headers for export/import/merge, so it needs no changes.

2. **Fix person lookup on Jellyfin 10.11.** `BaseItemRepository` builds [`CleanName` with `RemoveDiacritics().ToLowerInvariant()`](https://github.com/jellyfin/jellyfin/blob/v10.11.11/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs#L1438-L1446), but applies [`NameContains` directly via case-sensitive `Contains`](https://github.com/jellyfin/jellyfin/blob/v10.11.11/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs#L2014-L2027). Normalize the query with Jellyfin's existing extension, then use invariant, diacritic-insensitive comparisons for the in-memory filter while preserving the `caseSensitive` and `exactMatch` options. This fixes the shared lookup for ACTOR/DIRECTOR/WRITER/PRODUCER expressions and simple Actor/Director/Writer collections, for movies and series. Existing lowercase searches continue to work.

### Validation

- `dotnet build Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj` — passed with .NET SDK 9.0.317, Jellyfin 10.11.0; 0 warnings, 0 errors.
- The same build with `-p:JellyfinVersion=10.11.11` — passed; 0 warnings, 0 errors.
- A temporary local harness invoked the compiled `FindPersonsByName` method with an `ILibraryManager` proxy and literal CleanName fixtures: all 26 cases passed, including case variants, accented/unaccented names, partial/exact matches, case-sensitive rejection, and absent names. Reflection also verified the controller policy, six routed actions, and no anonymous overrides. The harness simulates the database prefilter; it does not run Jellyfin or its database.
- Manually inspected every configuration-page call for authentication. `git diff --check` passed. There is no existing unit-test project; no test framework or new normalization helper was added.

Manual integration cases for a Jellyfin library containing the corresponding credits (not run here):

- `DIRECTOR "Steven Spielberg"` and `DIRECTOR "steven spielberg"` should return the same nonempty results with case-sensitive matching disabled.
- `DIRECTOR "Krzysztof Kieślowski"` and `DIRECTOR "Krzysztof Kieslowski"` should return the same nonempty results.
- `ACTOR "Max von Sydow"` should return matching items.
- Confirm anonymous requests to all six endpoints are rejected, ordinary authenticated users cannot access them, and administrator requests still work through the configuration page.

Follow-up only: consider a maximum parser nesting depth (e.g. 64) and an expression length limit. The recursive expression parser currently has no such limits; sufficiently deep nesting can cause a process-terminating `StackOverflowException`. No parser changes are included.
