### PR TITLE
Target Jellyfin 12 (net10.0); require API auth; fix person lookup

### DIFF
--- a/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
+++ b/Jellyfin.Plugin.AutoCollections/Api/AutoCollectionsController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Providers;
@@ -35,6 +36,10 @@ namespace Jellyfin.Plugin.AutoCollections.Api
     /// The Auto Collections api controller.
     /// </summary>
     [ApiController]
+    // Every endpoint here is an admin operation: the sync and preview routes enumerate the
+    // whole library, and Export/Import/AddConfiguration read and overwrite plugin settings.
+    // Without this the controller inherits no policy at all and answers anonymous callers.
+    [Authorize(Policy = Policies.RequiresElevation)]
     [Route("AutoCollections")]
     [Produces(MediaTypeNames.Application.Json)]
 

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -16,6 +16,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Providers;
 using Jellyfin.Plugin.AutoCollections.Configuration;
@@ -1776,21 +1777,48 @@ namespace Jellyfin.Plugin.AutoCollections
         /// </remarks>
         private List<Person> FindPersonsByName(string nameToMatch, bool caseSensitive, bool exactMatch = false)
         {
-            StringComparison comparison = caseSensitive
-                ? StringComparison.Ordinal
-                : StringComparison.OrdinalIgnoreCase;
+            // Jellyfin stores Person.CleanName as Name.GetCleanValue() - diacritics stripped,
+            // lowercased, punctuation replaced by spaces, runs of whitespace collapsed - but
+            // matches NameContains against it with a plain, case-sensitive Contains. Handing
+            // it a raw name therefore silently misses everyone whose name differs from the
+            // query in case, diacritics or punctuation ("Steven Spielberg", "Kieslowski",
+            // "Robert Downey Jr."), so normalize the needle exactly the way the server did.
+            var cleanNeedle = nameToMatch.GetCleanValue();
 
-            return _libraryManager.GetItemList(new InternalItemsQuery
+            if (string.IsNullOrEmpty(cleanNeedle))
+            {
+                // Normalization can empty out a non-empty term (e.g. "..."). An empty
+                // NameContains disables the filter server-side, which would pull back every
+                // person in the library and match all of them, so stop here instead.
+                return new List<Person>();
+            }
+
+            var candidates = _libraryManager.GetItemList(new InternalItemsQuery
             {
                 IncludeItemTypes = new[] { BaseItemKind.Person },
                 Recursive = true,
-                NameContains = nameToMatch
-            }).OfType<Person>()
-                // NameContains is case-insensitive in the query, so a case-sensitive
-                // search still has to be narrowed down here.
-                .Where(p => p.Name != null && (exactMatch
-                    ? p.Name.Equals(nameToMatch, comparison)
-                    : p.Name.Contains(nameToMatch, comparison)))
+                NameContains = cleanNeedle
+            }).OfType<Person>().Where(p => p.Name != null);
+
+            // The query is only a prefilter: it knows nothing about caseSensitive or
+            // exactMatch, and normalization makes it match more broadly than asked. Apply
+            // the requested semantics here.
+            if (caseSensitive)
+            {
+                // Compare the untouched names, so case and diacritics both have to line up.
+                return candidates
+                    .Where(p => exactMatch
+                        ? string.Equals(p.Name, nameToMatch, StringComparison.Ordinal)
+                        : p.Name!.Contains(nameToMatch, StringComparison.Ordinal))
+                    .ToList();
+            }
+
+            // Insensitive matching compares normalized forms on both sides, so it stays
+            // consistent with what the query already did.
+            return candidates
+                .Where(p => exactMatch
+                    ? string.Equals(p.Name!.GetCleanValue(), cleanNeedle, StringComparison.Ordinal)
+                    : p.Name!.GetCleanValue().Contains(cleanNeedle, StringComparison.Ordinal))
                 .ToList();
         }
 

--- a/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
+++ b/Jellyfin.Plugin.AutoCollections/AutoCollectionsManager.cs
@@ -1023,9 +1023,9 @@ namespace Jellyfin.Plugin.AutoCollections
             catch (Exception ex) when (IsServerIncompatibility(ex))
             {
                 // The server exposes a different API surface than the one this plugin was built
-                // against - almost always a Jellyfin older than 10.11.
+                // against - almost always a Jellyfin older than 12.0.
                 _logger.LogError(ex,
-                    "Auto Collections could not run against this Jellyfin server. This plugin version requires Jellyfin 10.11 or newer; please update the server or install a plugin release matching it");
+                    "Auto Collections could not run against this Jellyfin server. This plugin version requires Jellyfin 12.0 or newer; please update the server or install a plugin release matching it");
                 throw;
             }
             finally
@@ -2744,7 +2744,7 @@ namespace Jellyfin.Plugin.AutoCollections
                 }
 
                 // Get all users and check if ANY of them have played this item.
-                // Resolved through JellyfinCompat because 10.11.9 replaced IUserManager.Users with GetUsers().
+                // Routed through JellyfinCompat so the user lookup has a single call site.
                 var users = JellyfinCompat.GetUsers(_userManager);
 
                 if (users.Count == 0)

--- a/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
+++ b/Jellyfin.Plugin.AutoCollections/Jellyfin.Plugin.AutoCollections.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <AssemblyVersion>0.0.7.0</AssemblyVersion>
-    <FileVersion>0.0.7.0</FileVersion>
+    <AssemblyVersion>0.0.8.0</AssemblyVersion>
+    <FileVersion>0.0.8.0</FileVersion>
     <Authors />
     <Company />
     <RootNamespace>Jellyfin.Plugin.AutoCollections</RootNamespace>
@@ -13,8 +13,8 @@
 
   <PropertyGroup>
     <!-- Lowest Jellyfin the plugin is built against. Overridable so the build can be
-         checked against newer 10.11.x releases: dotnet build -p:JellyfinVersion=10.11.11 -->
-    <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">10.11.0</JellyfinVersion>
+         checked against newer 12.0.x releases: dotnet build -p:JellyfinVersion=12.0.1 -->
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">12.0.0</JellyfinVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
     <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.11" />
+    <!-- Microsoft.Extensions.Logging is part of the Microsoft.AspNetCore.App framework
+         reference on net10.0; referencing the package explicitly warns as NU1510. -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.AutoCollections/JellyfinCompat.cs
+++ b/Jellyfin.Plugin.AutoCollections/JellyfinCompat.cs
@@ -1,8 +1,6 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Library;
 
@@ -11,58 +9,20 @@ namespace Jellyfin.Plugin.AutoCollections
     // ================================================================
     // SERVER COMPATIBILITY HELPERS
     // ================================================================
-    // Shims for Jellyfin APIs whose shape changed within the 10.11.x line.
-    // Binding these late keeps a single plugin binary working across every
-    // 10.11 server instead of hard-failing on the ones that moved a member.
+    // This used to late-bind IUserManager.Users / GetUsers() through reflection,
+    // because 10.11.9 renamed the member mid-line and one binary had to serve every
+    // 10.11 server. That shim is gone: the plugin now targets net10.0 / Jellyfin 12,
+    // which the .NET 9 based 10.11 servers cannot load at all, so the old shape is
+    // unreachable. Jellyfin 12 exposes GetUsers(), so call it directly - a missing
+    // member is now a load-time error instead of a silent empty user list.
     internal static class JellyfinCompat
     {
-        private static Func<IUserManager, IEnumerable<User>>? _usersAccessor;
-        private static bool _usersAccessorResolved;
-
         /// <summary>
         /// Returns every user known to the server.
-        /// 10.11.0-10.11.8 expose <c>IUserManager.Users</c>; 10.11.9 replaced it with
-        /// <c>GetUsers()</c>, which is a binary-breaking change for plugins compiled
-        /// against the older interface.
         /// </summary>
-        /// <returns>The users, or an empty list when neither member is available.</returns>
         public static IReadOnlyList<User> GetUsers(IUserManager userManager)
         {
-            var accessor = ResolveUsersAccessor();
-            if (accessor == null)
-            {
-                // Neither shape is present: a Jellyfin this plugin does not know about.
-                return Array.Empty<User>();
-            }
-
-            return accessor(userManager).ToList();
-        }
-
-        private static Func<IUserManager, IEnumerable<User>>? ResolveUsersAccessor()
-        {
-            if (_usersAccessorResolved)
-            {
-                return _usersAccessor;
-            }
-
-            // 10.11.9+: IEnumerable<User> GetUsers()
-            var getUsers = typeof(IUserManager).GetMethod("GetUsers", BindingFlags.Public | BindingFlags.Instance, Type.EmptyTypes);
-            if (getUsers != null && typeof(IEnumerable<User>).IsAssignableFrom(getUsers.ReturnType))
-            {
-                _usersAccessor = manager => (IEnumerable<User>)getUsers.Invoke(manager, null)!;
-            }
-            else
-            {
-                // 10.11.0-10.11.8: IEnumerable<User> Users { get; }
-                var users = typeof(IUserManager).GetProperty("Users", BindingFlags.Public | BindingFlags.Instance);
-                if (users != null && typeof(IEnumerable<User>).IsAssignableFrom(users.PropertyType))
-                {
-                    _usersAccessor = manager => (IEnumerable<User>)users.GetValue(manager)!;
-                }
-            }
-
-            _usersAccessorResolved = true;
-            return _usersAccessor;
+            return userManager.GetUsers().ToList();
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION := 0.0.7.0
+export VERSION := 0.0.8.0
 export GITHUB_REPO := KeksBombe/jellyfin-plugin-auto-collections
 export FILE := auto-collections-${VERSION}.zip
 
@@ -6,7 +6,7 @@ build:
 	dotnet build
 
 zip:
-	zip "${FILE}" Jellyfin.Plugin.AutoCollections/bin/Debug/net9.0/Jellyfin.Plugin.AutoCollections.dll
+	zip "${FILE}" Jellyfin.Plugin.AutoCollections/bin/Debug/net10.0/Jellyfin.Plugin.AutoCollections.dll
 
 csum:
 	md5sum "${FILE} ""

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ Either kind re-evaluates on every sync, so collections keep themselves current a
 
 ## 📋 Requirements
 
-- **Jellyfin**: Version 10.11 or later
+- **Jellyfin**: Version 12.0 or later
 - **Permissions**: Plugin requires collection management permissions
+
+> Jellyfin 12 moved the server to .NET 10, so a single plugin binary can no longer
+> serve both server lines. Releases `0.0.8.0` and newer target Jellyfin 12; stay on
+> `0.0.7.0` for Jellyfin 10.11. The plugin catalog offers each server the matching
+> release automatically.
 
 ## Share your config or find something cool!
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-auto-collections"
 guid: "06ebf4a9-1326-4327-968d-8da00e1ea2eb"
-version: "0.0.7.0" # Please increment with each pull request
-jellyfin_version: "10.11.0" # The earliest binary-compatible version
+version: "0.0.8.0" # Please increment with each pull request
+jellyfin_version: "12.0.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Auto Collections"
 description: "Automatically create Auto Collections based on matching strings in the metadata."
@@ -12,4 +12,4 @@ artifacts:
   - "Jellyfin.Plugin.AutoCollections.dll"
 build_type: "dotnet"
 dotnet_configuration: "Release"
-dotnet_framework: "netstandard2.1"
+dotnet_framework: "net10.0"

--- a/scripts/validate-and-update-manifest.js
+++ b/scripts/validate-and-update-manifest.js
@@ -6,7 +6,7 @@ const { URL } = require("url");
 const repository = process.env.GITHUB_REPO;
 const version = process.env.VERSION;
 const file = process.env.FILE;
-const targetAbi = "10.11.0.0";
+const targetAbi = "12.0.0.0";
 
 console.log(file);
 // Read manifest.json


### PR DESCRIPTION
Jellyfin `12.0.0` was published on 2026-09-08 and moves the server to **.NET 10**. `Jellyfin.Controller` 12.0.0 ships a `net10.0` target only, and a `net9.0` assembly will not load on a `net10.0` host — so the plugin has to move with it.

Three commits: the retarget, plus the two fixes from #124 reworked for Jellyfin 12.

---

## 1. Target Jellyfin 12 (`net10.0`)

- **Retarget to `net10.0`**, building against `Jellyfin.Controller` / `Jellyfin.Model` `12.0.0`.
- **Drop the explicit `Microsoft.Extensions.Logging` reference.** On `net10.0` it comes from the `Microsoft.AspNetCore.App` framework reference and now warns `NU1510`.
- **Fix the release Makefile**, which zipped from a hardcoded `bin/Debug/net9.0/` path — this would have silently shipped a stale DLL.
- **`targetAbi` → `12.0.0.0`** in `scripts/validate-and-update-manifest.js` for newly published manifest entries.
- **`build.yaml`**: `jellyfin_version` → `12.0.0`, and `dotnet_framework` corrected from the long-stale `netstandard2.1` to `net10.0`.
- Version bumped to `0.0.8.0`.

**Compatibility:** one binary can no longer serve both server lines. `0.0.8.0`+ targets Jellyfin 12; **Jellyfin 10.11 users stay on `0.0.7.0`**. Existing manifest entries keep their `10.11.0.0` ABI, so the plugin catalog offers each server the matching release automatically. README updated to say so.

**`JellyfinCompat` simplification.** The reflection shim there existed so a single build could cope with 10.11.9 renaming `IUserManager.Users` to `GetUsers()`. It is now unreachable — 10.11 servers cannot load a `net10.0` assembly at all — and its fallback returned an *empty user list* on failure, which would silently mis-evaluate every `unplayed` rule. Replaced with a direct `GetUsers()` call so a missing member surfaces as a load error instead.

**API check.** I diffed the 10.11.11 → 12.0.0 surface for every Jellyfin type this plugin touches. The breaking changes in `ILibraryManager` are all in members the plugin does not call:

| Changed in 12.0.0 | Used here? |
|---|---|
| `GetPeopleItems` now returns `QueryResult<T>` | No — plugin uses `GetPeople(item)`, unchanged |
| `DeleteItemsUnsafeFast` resignatured | No |
| `ValidatePeopleAsync` removed | No |
| `ResolvePath` resignatured | No |

Everything else in the diff was additive.

---

## 2. Require admin auth on the API endpoints

The controller carried **no authorization attribute**, so all six routes answered anonymous callers — including `ExportConfiguration` (reads settings) and `ImportConfiguration` / `AddConfiguration` (**overwrite** settings).

Applied `Policies.RequiresElevation` at the controller so every action inherits it. Jellyfin 12 exposes the policy names from `MediaBrowser.Common.Api`, so this uses the typed constant rather than the `"RequiresElevation"` string literal that #124 used.

I audited all six call sites in `configurationpage.html` before adding it — `Preview`/`PreviewAll` use `ApiClient.ajax`, the sync route uses `ApiClient.fetch`, and Export/Import/Add send an explicit `X-MediaBrowser-Token`. The configuration page needs no changes.

---

## 3. Fix person lookup against Jellyfin 12 `CleanName`

**Still broken on 12, and #124's fix is not sufficient there.**

Jellyfin stores `Person.CleanName` as `Name.GetCleanValue()` but applies `NameContains` to it with a plain, **case-sensitive** `Contains` ([`TranslateQuery.cs#L491-505`](https://github.com/jellyfin/jellyfin/blob/v12.0/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs#L491-L505)). Passing the raw term never matched: querying `"Steven Spielberg"` tested whether `"steven spielberg"` contains `"Steven Spielberg"` → false.

Jellyfin 12 also **changed what that normalization does**. [`GetCleanValue()`](https://github.com/jellyfin/jellyfin/blob/v12.0/src/Jellyfin.Extensions/StringExtensions.cs#L159-L176) now replaces punctuation with spaces and collapses whitespace on top of removing diacritics and lowercasing. 10.11 only did `RemoveDiacritics().ToLowerInvariant()`. So #124's lowercasing fixes case and diacritics but still misses every name containing punctuation:

| query | before | #124 | this PR |
|---|---|---|---|
| `Steven Spielberg` | 0 | 1 | 1 |
| `Krzysztof Kieślowski` | 0 | 1 | 1 |
| `Robert Downey Jr.` | 0 | **0** | 1 |
| `Conan O'Brien` | 0 | **0** | 1 |

This normalizes the needle with the same `GetCleanValue()` the server used to build `CleanName`. The query stays a prefilter, so `caseSensitive` and `exactMatch` are still applied in memory: case-sensitive searches compare untouched names, insensitive ones compare normalized forms on both sides.

Also guards the empty result of normalizing a punctuation-only term (e.g. `"..."`) — an empty `NameContains` disables the filter server-side, which would return **every** person in the library and match all of them.

Affects `ACTOR`/`DIRECTOR`/`WRITER`/`PRODUCER` expressions and the simple Actor/Director/Writer collections, for movies and series.

---

## Verification

Clean build: **0 warnings, 0 errors**. Emitted assembly is `v0.0.8.0`, binding `MediaBrowser.Controller 12.0.0.0` / `Jellyfin.Data 12.0.0.0` on the .NET 10 BCL.

A temporary harness loaded the compiled plugin, drove `FindPersonsByName` through an `ILibraryManager` proxy that reproduces Jellyfin 12's `CleanName.Contains` prefilter, and reflected over the controller — **37/37 checks passed**: case variants, accented/unaccented spellings, punctuation (periods, apostrophes, hyphens), partial vs exact, case-sensitive acceptance and rejection, absent names, the punctuation-only and empty-needle guards, and that the normalized `NameContains` actually reaches the server. Plus the policy, the six routed actions, and the absence of any `[AllowAnonymous]` override.

The harness simulates the query translation; **it does not run Jellyfin or its database, and none of this is runtime-tested against a live Jellyfin 12 server.**

Supersedes #124.
